### PR TITLE
added a na.rm=FALSE warning to sum.im

### DIFF
--- a/R/images.R
+++ b/R/images.R
@@ -796,8 +796,8 @@ sum.im <- range.im <- max.im <- min.im <- function(x, ...) {
   verifyclass(x, "im")
   argh <- list(x, ...)
   if(length(argh)>=2) {
-     if("na.rm" %in% names(argh) && argh[["na.rm"]]){
-         warning("function always ignores NA values, consider using sum(image[,], na.rm=TRUE) instead")
+     if("na.rm" %in% names(argh) && (argh[["na.rm"]]!=TRUE)){
+         warning("function always ignores NA and NaN values, consider using sum(image[,], na.rm=FALSE) instead")
      }
   }
 

--- a/R/images.R
+++ b/R/images.R
@@ -795,6 +795,12 @@ median.im <- function(x, ...) {
 sum.im <- range.im <- max.im <- min.im <- function(x, ...) {
   verifyclass(x, "im")
   argh <- list(x, ...)
+  if(length(argh)>=2) {
+     if("na.rm" %in% names(argh) && argh[["na.rm"]]){
+         warning("function always ignores NA values, consider using sum(image[,], na.rm=TRUE) instead")
+     }
+  }
+
   isim <- sapply(argh, is.im)
   argh[isim] <- lapply(argh[isim], "[", drop=TRUE)
   names(argh)[isim] <- ""


### PR DESCRIPTION
warning also affects min.im, max.im and range.im. Ignoring NA and NaN values in these functions comes from the behaviour of [.im with the drop=TRUE option.