### PR TITLE
bandwidth selection for pcf/pcfinhom

### DIFF
--- a/R/bw.pcf.R
+++ b/R/bw.pcf.R
@@ -1,0 +1,137 @@
+## bandwidth selection with Least-Squres Cross-Validation method
+# By: Rasmus Waagepetersen and Abdollah Jalilian
+# reference
+# Guan, Y. (2007). A composite likelihood cross-validation approach in 
+#   selecting bandwidth for the estimation of the pair correlation function. 
+#   Scandinavian Journal of Statistics, 34(2), 336–346. 
+#   DOI: http://doi.org/10.1111/j.1467-9469.2006.00533.x
+# Guan, Y. (2007). A least-squares cross-validation bandwidth 
+#   selection approach in pair correlation function estimations. 
+#   Statistics & Probability Letters, 77(18), 1722–1729. 
+#   DOI: http://doi.org/10.1016/j.spl.2007.04.016
+
+bw.pcf <- function(X, rmax=NULL, lambda=NULL, divisor="r", 
+                   kernel="epanechnikov", nr=10000, bias.correct=TRUE, 
+                   cv.method="compLik", simple=TRUE, ...)
+{
+  win <- Window(X)
+  areaW <- area(win)
+  
+  # maximum distance lag: rmax
+  if (is.null(rmax))
+    rmax <- rmax.rule("K", win,  npoints(X)/areaW)
+  #rmax <- rmax + 0.15/sqrt(npoints(X)/areaW)
+  # number of subintervals for discretization of [0, rmax]: nr
+  # length of subintervals
+  discr <- rmax / nr
+  # breaks of subintervals
+  rs <- seq(0, rmax, length.out= nr + 1)
+  
+  cp <- closepairs(X, rmax, what="all", twice=TRUE)
+  # closepairs distances: \\ u - v \\
+  ds <- cp$d
+  # determining closepairs distances are in which subinterval
+  idx <- round(ds / discr) + 1
+  
+  # translation edge correction faqctor: /W|/|W \cap W_{u-v}|
+  edgewt <- edge.Trans(dx=cp$dx, dy=cp$dy, W=win, paired=TRUE)
+  
+  if (is.null(lambda))
+  {
+    # homogeneous case
+    lambda <- npoints(X)/areaW
+    lambda2area <- lambda^2 * areaW
+    gfun <- function(bw)
+    {
+      pcf(X, r=rs, bw=bw, divisor=divisor, kernel=kernel,
+          correction="translate")$trans
+    }
+    renorm.factor <- 1
+  } else
+  {
+    # inhomogeneous case: lambda is asssumed to be a numeric vector giving
+    # the intenisty at the points of the point pattern X
+    lambda2area <- lambda[cp$i] * lambda[cp$j] * areaW
+    gfun <- function(bw)
+    {
+      pcfinhom(X, r=rs, lambda=lambda, bw=bw, divisor=divisor, 
+               kernel=kernel, correction="translate")$trans
+    }
+    renorm.factor <- (areaW/sum(1/lambda))
+  }
+  
+  # kernel function
+  # integral of kernel function: int_{-h}^{d} k(r) dr
+  switch(kernel, epanechnikov={
+    kerfun <- function(d, bw)
+    {
+      h <- sqrt(5) * bw
+      ifelse(abs(d) < h, 0.75 * (1 - (d/h)^2)/h, 0)
+    }
+    integkerfun <- function(d, bw)
+    {
+      h <- sqrt(5) * bw
+      ifelse(d <= h, 3/4 * (1 + d / h) - 1/4 * (1 + d^3 / h^3), 1)
+    }
+  }, rectangular={
+    kerfun <- function(d, bw) 
+    {
+      h <- sqrt(3) * bw
+      ifelse(abs(d) < h, 0.5/h, 0)
+    }
+    integkerfun <- function(d, bw)
+    {
+      h <- sqrt(3) * bw
+      ifelse(d <= h, 1/2 * (1 + d/h), 1)
+    }
+  }, stop("the specified kernel is not implemented yet!"))
+  
+  cvfun <- function(bw)
+  {
+    # values of pair correlation at breaks of subintervals 
+    grs <- gfun(bw)
+    # bias correction
+    if (bias.correct)
+    {
+      grs <- grs / integkerfun(rs, bw)
+      dcorrec <- integkerfun(ds, bw)
+    } else{
+      dcorrec <- 1
+    }
+    # make sure that the estimated pair correlation at origin is finite
+    if (!is.finite(grs[1]))
+      grs[1] <- grs[2]
+    # approximate the pair correlation values at closepairs distances
+    gds <- grs[idx]
+    wt <- edgewt / (2 * pi * ds * lambda2area * dcorrec) * renorm.factor
+    # remove pairs to approximate the cross-validation term: g^{-(u, v)}
+    if (simple)
+    {
+      gds <- gds - 2 * wt * kerfun(0, bw)
+    } else{
+      for (k in 1:length(ds))
+      {
+        exclude <- (cp$i == cp$i[k]) | (cp$j == cp$j[k])
+        gds[k] <- gds[k] - 2 * sum(wt[exclude] * 
+                                     kerfun(ds[k] - ds[exclude], bw))
+      }
+    }
+    
+    switch(cv.method, compLik={  # composite likelihood cross-validation
+      # the integral term: 2 \pi \int_{0}^{rmax} \hat g(r) r dr
+      normconst <- 2 * pi * sum(grs * rs) * discr
+      return(mean(log(gds)) - log(normconst))
+    }, leastSQ={  # least squares cross-validation
+      # the integral term: 2 \pi \int_{0}^{rmax} \hat g^2(r) r dr
+      normconst <- 2 * pi * sum(grs^2 * rs) * discr
+      return(2 * sum(gds * edgewt / (lambda2area)) - normconst)
+    }, stop("wrong cross-validation method"))
+  }
+  
+  dyt <- optimize(cvfun, lower=0, upper=rmax / 4, maximum=TRUE)
+  
+  return(dyt$maximum)
+}
+
+# example
+# bw.pcf(redwood)

--- a/man/bw.pcf.Rd
+++ b/man/bw.pcf.Rd
@@ -1,0 +1,128 @@
+\name{bw.pcf}
+\alias{bw.pcf}
+\title{
+  Cross Validated Bandwidth Selection for Pair Correlation Function
+}
+\description{
+  Uses composite likelihood or generalized least squares 
+  cross-validation to select a smoothing bandwidth
+  for the kernel estimation of pair correlation function.
+}
+\usage{
+  bw.pcf(X, rmax=NULL, lambda=NULL, divisor="r", 
+         kernel="epanechnikov", nr=10000, bias.correct=TRUE, 
+         cv.method="compLik", simple=TRUE, ...)
+}
+\arguments{
+  \item{X}{
+    A point pattern (object of class \code{"ppp"}).
+  }
+  \item{rmax}{
+    Numeric. Maximum value of the spatial lag distance \eqn{r} 
+    for which \eqn{g(r)} should be evaluated.
+  }
+  \item{lambda}{
+    Optional.
+    Values of the estimated intensity function.
+    A vector giving the intensity values
+    at the points of the pattern \code{X}.
+  }
+  \item{divisor}{
+    Choice of divisor in the estimation formula:
+    either \code{"r"} (the default) or \code{"d"}. 
+    See \code{pcf.ppp}.
+  }
+  \item{kernel}{
+    Choice of smoothing kernel, passed to \code{density}; 
+    see \code{\link{pcf}} and \code{\link{pcfinhom}}.
+  }
+  \item{nr}{
+    Integer. Number of subintervals for discretization of 
+    [0, rmax] to use in computing numerical integrals.
+  }
+  \item{bias.correct}{
+    Logical. Whether to use bias corrected version of the kernel 
+    estimate. See Details.
+  }
+  \item{cv.method}{
+    Choice of cross validation method.
+  }
+  \item{simple}{
+    Logical. Whether to use simple removal of spatial lag 
+    distances. See Details.
+  }
+  \item{\dots}{
+    Other arguments, passed to \code{\link{pcf}} or 
+    \code{\link{pcfinhom}}.
+  }
+}
+\details{
+  This function selects an appropriate bandwidth \code{bw}
+  for the kernel estimator of the pair correlation function 
+  of a point process intensity computed by \code{\link{pcf.ppp}} 
+  (homogeneous case) or \code{\link{pcfinhom}} 
+  (inhomogeneous case).
+
+  With \code{cv.method="leastSQ"}, the bandwidth 
+  \eqn{h}{h} is chosen to minimise an unbiased 
+  estimate of the integrated mean-square error criterion 
+  \eqn{M(h)} defined in equation (4) in Guan (2007a).
+  
+  With \code{cv.method="compLik"}, the bandwidth 
+  \eqn{h}{h} is chosen to maximise a likelihood 
+  cross-validation criterion \eqn{CV(h)} defined in 
+  equation (6) of Guan (2007b).
+  
+  \deqn{
+    M(b) = \frac{\mbox{MSE}(\sigma)}{\lambda^2} - g(0)
+  }{
+    M(b) = \int_{0}^{rmax} \hat{g}^2(r;b) r dr - \sum_{u,v}
+  }
+
+  The result is a numerical value giving the selected bandwidth.
+}
+\section{Definition of bandwidth}{
+  The bandwidth \code{bw} returned by \code{bw.pcf}
+  corresponds to the standard deviation of the smoothoing 
+  kernel. As mentioned in the documentation of 
+  \code{\link{density.default}} and \code{\link{pcf.ppp}}, 
+  this differs from the scale parameter \code{h} of 
+  the smoothing kernel which is often considered in the 
+  literature as the bandwidth of the kernel function.
+  For example for the Epanechnikov kernel, \code{bw=h/sqrt(h)}.
+}
+\value{
+  A numerical value giving the selected bandwidth.
+  The result also belongs to the class \code{"bw.optim"}
+  which can be plotted.
+}
+\seealso{
+  \code{\link{pcf.ppp}},
+  \code{\link{pcfinhom}}
+}
+\examples{
+  data(redwood)
+  bw <- bw.pcf(redwood)
+  plot(pcf(redwood, bw=bw))
+}
+\references{
+  Guan, Y. (2007a). 
+  A composite likelihood cross-validation approach in selecting 
+  bandwidth for the estimation of the pair correlation function. 
+  \emph{Scandinavian Journal of Statistics}, 
+  \bold{34}(2), 336--346.
+  
+  Guan, Y. (2007b). 
+  A least-squares cross-validation bandwidth selection approach 
+  in pair correlation function estimations. 
+  \emph{Statistics & Probability Letters}, 
+  \bold{77}(18), 1722--1729.
+}
+\author{
+  Rasmus Waagepetersen and Abdollah Jalilian. 
+  Adapted for spatstat by \adrian
+  and \rolf
+}
+\keyword{spatial}
+\keyword{methods}
+\keyword{smooth}


### PR DESCRIPTION
Dear maintainers of spatstat, 

This is a pull request to include an implementation of composite likelihood and generalized least squares cross-validation methods by Y. Guan (2007a, 2007b) to select a smoothing bandwidth for the kernel estimation of pair correlation function. The code and documentation might need some correction/polishing to comply with spatstat. 

Best regards,

Abdollah
