### PR TITLE
added PACKAGE = "spatstat"

### DIFF
--- a/R/FGmultiInhom.R
+++ b/R/FGmultiInhom.R
@@ -148,7 +148,8 @@ GmultiInhom <- function(X, I, J,
           vdata = as.double(vJord),
           nr = as.integer(nr),
           rmax = as.double(rmax),
-          ans = as.double(numeric(nI * nr)))
+          ans = as.double(numeric(nI * nr)),
+          PACKAGE = "spatstat")
   ans <- matrix(z$ans, nrow=nr, ncol=nI)
   #' revert to original ordering
   loccumprod <- matrix(,  nrow=nr, ncol=nI)

--- a/R/Jinhom.R
+++ b/R/Jinhom.R
@@ -127,7 +127,8 @@ Ginhom <- function(X, lambda=NULL, lmin=NULL,
           v = as.double(vord),
           nr = as.integer(nr),
           rmax = as.double(rmax),
-          ans = as.double(numeric(npts * nr)))
+          ans = as.double(numeric(npts * nr)),
+          PACKAGE = "spatstat")
   ans <- matrix(z$ans, nrow=nr, ncol=npts)
   # revert to original ordering
   loccumprod <- matrix(,  nrow=nr, ncol=npts)
@@ -303,7 +304,8 @@ Finhom <- function(X, lambda=NULL, lmin=NULL,
          vdata = as.double(vord),
          nr = as.integer(nr),
          rmax = as.double(rmax),
-         ans = as.double(numeric(nM * nr)))
+         ans = as.double(numeric(nM * nr)),
+         PACKAGE = "spatstat")
   loccumprod <- matrix(z$ans, nrow=nr, ncol=nM)
   # border correction
   ok <- outer(r, bM, "<=")

--- a/R/Kest.R
+++ b/R/Kest.R
@@ -475,7 +475,8 @@ Kborder.engine <- function(X, rmax, nr=100,
                 nr=as.integer(nr),
                 rmax=as.double(rmax),
                 numer=as.integer(integer(nr)),
-                denom=as.integer(integer(nr)))
+                denom=as.integer(integer(nr)),
+                PACKAGE = "spatstat")
     } else {
       # no - need double precision storage
       res <- .C("KborderD",
@@ -486,7 +487,8 @@ Kborder.engine <- function(X, rmax, nr=100,
                 nr=as.integer(nr),
                 rmax=as.double(rmax),
                 numer=as.double(numeric(nr)),
-                denom=as.double(numeric(nr)))
+                denom=as.double(numeric(nr)),
+                PACKAGE = "spatstat")
     }
     if("bord.modif" %in% correction) {
       denom.area <- eroded.areas(W, r)
@@ -547,7 +549,8 @@ Kborder.engine <- function(X, rmax, nr=100,
               nr=as.integer(nr),
               rmax=as.double(rmax),
               numer=as.double(numeric(nr)),
-              denom=as.double(numeric(nr)))
+              denom=as.double(numeric(nr)),
+              PACKAGE = "spatstat")
     if("border" %in% correction) {
       bord <- res$numer/res$denom
       Kfv <- bind.fv(Kfv, data.frame(border=bord), "hat(%s)[bord](r)",
@@ -650,7 +653,8 @@ Knone.engine <- function(X, rmax, nr=100,
                 y=as.double(y),
                 nr=as.integer(nr),
                 rmax=as.double(rmax),
-                numer=as.integer(integer(nr)))
+                numer=as.integer(integer(nr)),
+                PACKAGE = "spatstat")
     } else {
       # no - need double precision storage
       res <- .C("KnoneD",
@@ -659,7 +663,8 @@ Knone.engine <- function(X, rmax, nr=100,
                 y=as.double(y),
                 nr=as.integer(nr),
                 rmax=as.double(rmax),
-                numer=as.double(numeric(nr)))
+                numer=as.double(numeric(nr)),
+                PACKAGE = "spatstat")
     }
 
     numKun <- res$numer
@@ -684,7 +689,8 @@ Knone.engine <- function(X, rmax, nr=100,
               w=as.double(weights.Xsort),
               nr=as.integer(nr),
               rmax=as.double(rmax),
-              numer=as.double(numeric(nr)))
+              numer=as.double(numeric(nr)),
+              PACKAGE = "spatstat")
     numKun <- res$numer
     denKun <- sum(weights)
     Kun <- numKun/denKun
@@ -875,7 +881,8 @@ Krect.engine <- function(X, rmax, nr=100,
               trans=as.double(ztrans),
               bnumer=as.double(zbnumer),
               bdenom=as.double(zbdenom),
-              unco=as.double(zunco))
+              unco=as.double(zunco),
+              PACKAGE = "spatstat")
   } else if(npts < sqrt(.Machine$integer.max)) {
     ## unweighted
     ## numerator of border correction can be stored as an integer
@@ -900,7 +907,8 @@ Krect.engine <- function(X, rmax, nr=100,
               trans=as.double(ztrans),
               bnumer=as.integer(zbnumer),
               bdenom=as.integer(zbdenom),
-              unco=as.integer(zunco))
+              unco=as.integer(zunco),
+              PACKAGE = "spatstat")
   } else {
     ## unweighted
     ## need double precision storage
@@ -924,7 +932,8 @@ Krect.engine <- function(X, rmax, nr=100,
               trans=as.double(ztrans),
               bnumer=as.double(zbnumer),
               bdenom=as.double(zbdenom),
-              unco=as.double(zunco))
+              unco=as.double(zunco),
+              PACKAGE = "spatstat")
   }
 
   ## Process corrections in reverse order of priority

--- a/R/areadiff.R
+++ b/R/areadiff.R
@@ -202,7 +202,8 @@ areaGain.grid <- function(u, X, r, ..., W=NULL, ngrid=spatstat.options("ngrid.di
               y   = as.double(yshift[close]),
               nn  = as.integer(nclose),
               ngrid = as.integer(ngrid),
-              answer = as.double(numeric(nr)))
+              answer = as.double(numeric(nr)),
+              PACKAGE = "spatstat")
       result[i,] <- z$answer
     } else {
       z <- .C("areaBdif",
@@ -216,7 +217,8 @@ areaGain.grid <- function(u, X, r, ..., W=NULL, ngrid=spatstat.options("ngrid.di
               y0 = as.double(W$yrange[1L] - yu),
               x1 = as.double(W$xrange[2L] - xu),
               y1 = as.double(W$yrange[2L] - yu),
-              answer = as.double(numeric(nr)))
+              answer = as.double(numeric(nr)),
+              PACKAGE = "spatstat")
       result[i,] <- z$answer
     }
   }

--- a/R/areainter.R
+++ b/R/areainter.R
@@ -200,7 +200,8 @@ areadelta2 <- local({
                 yother = as.double(yy[K]),
                 radius = as.double(r),
                 epsilon = as.double(eps),
-                pixcount = as.integer(integer(1L)))
+                pixcount = as.integer(integer(1L)),
+                PACKAGE = "spatstat")
         result[i,j] <- result[j,i] <- z$pixcount
       }
       # normalise
@@ -345,7 +346,8 @@ areadelta2 <- local({
             yother = as.double(yy[K]),
             radius = as.double(r),
             epsilon = as.double(eps),
-            pixcount = as.integer(integer(1L)))
+            pixcount = as.integer(integer(1L)),
+            PACKAGE = "spatstat")
       result[i,j] <- z$pixcount
     }
     # normalise

--- a/R/bw.diggle.R
+++ b/R/bw.diggle.R
@@ -69,7 +69,8 @@ bw.diggle <- local({
                      nr=as.integer(nr),
                      nrmax=as.integer(nrmax),
                      ndK=as.integer(ndK),
-                     J=as.double(numeric(nrmax)))
+                     J=as.double(numeric(nrmax)),
+                     PACKAGE = "spatstat")
              J <- z$J
              rvals <- rvals[ok]
            })

--- a/R/clip.psp.R
+++ b/R/clip.psp.R
@@ -178,7 +178,8 @@ clippoly.psp <- function(s, window) {
             yy=as.double(numeric(ns * nw)),
             ta=as.double(numeric(ns * nw)),
             tb=as.double(numeric(ns * nw)),
-            ok=as.integer(integer(ns * nw)))
+            ok=as.integer(integer(ns * nw)),
+            PACKAGE = "spatstat")
 
   ok <- (matrix(out$ok, ns, nw) != 0)
   ts <- matrix(out$ta, ns, nw)

--- a/R/close3Dpairs.R
+++ b/R/close3Dpairs.R
@@ -62,11 +62,13 @@ closepairs.pp3 <- local({
     a <- switch(what,
                 all = {
                   .Call("close3pairs",
-                        xx=x, yy=y, zz=z, rr=r, nguess=ng)
+                        xx=x, yy=y, zz=z, rr=r, nguess=ng),
+                        PACKAGE = "spatstat"
                 },
                 indices = {
                   .Call("close3IJpairs",
-                        xx=x, yy=y, zz=z, rr=r, nguess=ng)
+                        xx=x, yy=y, zz=z, rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
                 })
     names(a) <- nama
     ## convert i,j indices to original sequence
@@ -186,13 +188,15 @@ crosspairs.pp3 <- local({
                   .Call("cross3pairs",
                         xx1=Xx, yy1=Xy, zz1=Xz,
                         xx2=Yx, yy2=Yy, zz2=Yz,
-                        rr=r, nguess=ng)
+                        rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
                 },
                 indices = {
                   .Call("cross3IJpairs",
                         xx1=Xx, yy1=Xy, zz1=Xz,
                         xx2=Yx, yy2=Yy, zz2=Yz,
-                        rr=r, nguess=ng)
+                        rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
                 })
     names(a) <- nama
     ## convert i,j indices to original sequence

--- a/R/closepairs.R
+++ b/R/closepairs.R
@@ -78,7 +78,8 @@ closepairs.ppp <- function(X, rmax, twice=TRUE,
     switch(what,
            all = {
              z <- .Call("Vclosepairs",
-                        xx=x, yy=y, rr=r, nguess=ng)
+                        xx=x, yy=y, rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
              if(length(z) != 9)
                stop("Internal error: incorrect format returned from Vclosepairs")
              i  <- z[[1L]]  # NB no increment required
@@ -93,7 +94,8 @@ closepairs.ppp <- function(X, rmax, twice=TRUE,
            },
            indices = {
              z <- .Call("VcloseIJpairs",
-                        xx=x, yy=y, rr=r, nguess=ng)
+                        xx=x, yy=y, rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
              if(length(z) != 2)
                stop("Internal error: incorrect format returned from VcloseIJpairs")
              i  <- z[[1L]]  # NB no increment required
@@ -101,7 +103,8 @@ closepairs.ppp <- function(X, rmax, twice=TRUE,
            },
            ijd = {
              z <- .Call("VcloseIJDpairs",
-                        xx=x, yy=y, rr=r, nguess=ng)
+                        xx=x, yy=y, rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
              if(length(z) != 3)
                stop("Internal error: incorrect format returned from VcloseIJDpairs")
              i  <- z[[1L]]  # NB no increment required
@@ -406,7 +409,8 @@ crosspairs.ppp <- function(X, Y, rmax, what=c("all", "indices", "ijd"), ...) {
              z <- .Call("Vcrosspairs",
                         xx1=Xx, yy1=Xy,
                         xx2=Yx, yy2=Yy,
-                        rr=r, nguess=ng)
+                        rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
              if(length(z) != 9)
                stop("Internal error: incorrect format returned from Vcrosspairs")
              i  <- z[[1L]]  # NB no increment required
@@ -423,7 +427,8 @@ crosspairs.ppp <- function(X, Y, rmax, what=c("all", "indices", "ijd"), ...) {
              z <- .Call("VcrossIJpairs",
                         xx1=Xx, yy1=Xy,
                         xx2=Yx, yy2=Yy,
-                        rr=r, nguess=ng)
+                        rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
              if(length(z) != 2)
                stop("Internal error: incorrect format returned from VcrossIJpairs")
              i  <- z[[1L]]  # NB no increment required
@@ -433,7 +438,8 @@ crosspairs.ppp <- function(X, Y, rmax, what=c("all", "indices", "ijd"), ...) {
              z <- .Call("VcrossIJDpairs",
                         xx1=Xx, yy1=Xy,
                         xx2=Yx, yy2=Yy,
-                        rr=r, nguess=ng)
+                        rr=r, nguess=ng,
+                        PACKAGE = "spatstat")
              if(length(z) != 3)
                stop("Internal error: incorrect format returned from VcrossIJDpairs")
              i  <- z[[1L]]  # NB no increment required
@@ -566,7 +572,8 @@ closethresh <- function(X, R, S, twice=TRUE, ...) {
   storage.mode(s) <- "double"
   storage.mode(ng) <- "integer"
   z <- .Call("Vclosethresh",
-             xx=x, yy=y, rr=r, ss=s, nguess=ng)
+             xx=x, yy=y, rr=r, ss=s, nguess=ng,
+             PACKAGE = "spatstat")
   if(length(z) != 3)
     stop("Internal error: incorrect format returned from Vclosethresh")
   i  <- z[[1L]]  # NB no increment required

--- a/R/closepairs.R
+++ b/R/closepairs.R
@@ -158,7 +158,8 @@ closepairs.ppp <- function(X, rmax, twice=TRUE,
          dxout=as.double(numeric(nsize)),
          dyout=as.double(numeric(nsize)),
          dout=as.double(numeric(nsize)),
-         status=as.integer(integer(1L)))
+         status=as.integer(integer(1L)),
+         PACKAGE = "spatstat")
 
     if(z$status != 0) {
       # Guess was insufficient
@@ -170,7 +171,8 @@ closepairs.ppp <- function(X, rmax, twice=TRUE,
                   x=as.double(Xsort$x),
                   y=as.double(Xsort$y),
                   rmaxi=as.double(rmaxplus),
-                  count=as.integer(integer(1L)))$count
+                  count=as.integer(integer(1L)),
+                  PACKAGE = "spatstat")$count
       if(nsize <= 0)
         return(null.answer)
       # add a bit more for safety
@@ -193,7 +195,8 @@ closepairs.ppp <- function(X, rmax, twice=TRUE,
            dxout=as.double(numeric(nsize)),
            dyout=as.double(numeric(nsize)),
            dout=as.double(numeric(nsize)),
-           status=as.integer(integer(1L)))
+           status=as.integer(integer(1L)),
+           PACKAGE = "spatstat")
       if(z$status != 0)
         stop(paste("Internal error: C routine complains that insufficient space was allocated:", nsize))
     }
@@ -451,7 +454,8 @@ crosspairs.ppp <- function(X, Y, rmax, what=c("all", "indices", "ijd"), ...) {
                 x2=as.double(Ysort$x),
                 y2=as.double(Ysort$y),
                 rmaxi=as.double(rmaxplus),
-                count=as.integer(integer(1L)))$count
+                count=as.integer(integer(1L)),
+                PACKAGE = "spatstat")$count
     if(nsize <= 0)
       return(null.answer)
 
@@ -479,7 +483,8 @@ crosspairs.ppp <- function(X, Y, rmax, what=c("all", "indices", "ijd"), ...) {
          dxout=as.double(numeric(nsize)),
          dyout=as.double(numeric(nsize)),
          dout=as.double(numeric(nsize)),
-         status=as.integer(integer(1L)))
+         status=as.integer(integer(1L)),
+         PACKAGE = "spatstat")
     if(z$status != 0)
       stop(paste("Internal error: C routine complains that insufficient space was allocated:", nsize))
     # trim vectors to the length indicated

--- a/R/connected.R
+++ b/R/connected.R
@@ -43,7 +43,8 @@ connected.owin <- function(X, ..., method="C") {
     z <- .C("cocoImage",
             mat=as.integer(t(L)),
             nr=as.integer(nr),
-            nc=as.integer(nc))
+            nc=as.integer(nc),
+            PACKAGE = "spatstat")
     # unpack
     Z <- matrix(z$mat, nr+2, nc+2, byrow=TRUE)
   } else {
@@ -161,7 +162,8 @@ connected.ppp <- function(X, R, ...) {
            ie=as.integer(ie),
            je=as.integer(je),
            label=as.integer(integer(nv)),
-           status=as.integer(integer(1L)))
+           status=as.integer(integer(1L)),
+           PACKAGE = "spatstat")
   if(zz$status != 0)
     stop("Internal error: connected.ppp did not converge")
   if(internal)

--- a/R/crossdistlpp.R
+++ b/R/crossdistlpp.R
@@ -99,7 +99,8 @@ crossdist.lpp <- function(X, Y, ..., method="C") {
              dpath = as.double(dpath),
              psegmap = as.integer(Xsegmap),
              qsegmap = as.integer(Ysegmap),
-             answer = as.double(crossdistmat))
+             answer = as.double(crossdistmat),
+             PACKAGE = "spatstat")
     crossdistmat <- matrix(zz$answer, nX, nY)
   }
   return(crossdistmat)

--- a/R/deldir.R
+++ b/R/deldir.R
@@ -73,7 +73,8 @@ delaunay <- function(X) {
             it = as.integer(integer(ne)),
             jt = as.integer(integer(ne)),
             kt = as.integer(integer(ne)),
-            status = as.integer(integer(1L)))
+            status = as.integer(integer(1L)),
+            PACKAGE = "spatstat")
     if(z$status != 0)
       stop("Internal error: overflow in trigrafS")
     tlist <- with(z, cbind(it, jt, kt)[1:nt, ])
@@ -91,7 +92,8 @@ delaunay <- function(X) {
             it = as.integer(integer(ntmax)),
             jt = as.integer(integer(ntmax)),
             kt = as.integer(integer(ntmax)),
-            status = as.integer(integer(1L)))
+            status = as.integer(integer(1L)),
+            PACKAGE = "spatstat")
     if(z$status != 0)
       stop("Internal error: overflow in trigraf")
     tlist <- with(z, cbind(it, jt, kt)[1:nt, ])
@@ -228,7 +230,8 @@ delaunayDistance <- function(X) {
           dpath = as.integer(integer(nY * nY)),
           tol = as.integer(0),
           niter = as.integer(integer(1L)), 
-          status = as.integer(integer(1L)))
+          status = as.integer(integer(1L)),
+          PACKAGE = "spatstat")
   if (z$status == -1L)
     warning(paste("graph connectivity algorithm did not converge after", 
                   z$niter, "iterations", "on", nY, "vertices and", 

--- a/R/density.ppp.R
+++ b/R/density.ppp.R
@@ -337,7 +337,8 @@ densitypointsEngine <- function(x, sigma, ...,
                x       = as.double(xx),
                y       = as.double(yy),
                rmaxi   = as.double(cutoff),
-               result  = as.double(double(npts)))
+               result  = as.double(double(npts)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[oo] <- zz$result
       result <- result * const
     } else if(k == 1L) {
@@ -348,7 +349,8 @@ densitypointsEngine <- function(x, sigma, ...,
                y       = as.double(yy),
                rmaxi   = as.double(cutoff),
                weight  = as.double(wtsort),
-               result  = as.double(double(npts)))
+               result  = as.double(double(npts)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[oo] <- zz$result 
       result <- result * const
     } else {
@@ -361,7 +363,8 @@ densitypointsEngine <- function(x, sigma, ...,
                  y       = as.double(yy),
                  rmaxi   = as.double(cutoff),
                  weight  = as.double(wtsort[,j]),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result[,j] <- zz$result else result[oo,j] <- zz$result
       }
       result <- result * const
@@ -390,7 +393,8 @@ densitypointsEngine <- function(x, sigma, ...,
                  y       = as.double(yy),
                  rmaxi   = as.double(cutoff),
                  sig     = as.double(sd),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result 
       } else if(k == 1L) {
         wtsort <- if(sorted) weights else weights[oo]
@@ -401,7 +405,8 @@ densitypointsEngine <- function(x, sigma, ...,
                  rmaxi   = as.double(cutoff),
                  sig     = as.double(sd),
                  weight  = as.double(wtsort),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result 
        } else {
         # matrix of weights
@@ -414,7 +419,8 @@ densitypointsEngine <- function(x, sigma, ...,
                    rmaxi   = as.double(cutoff),
                    sig     = as.double(sd),
                    weight  = as.double(wtsort[,j]),
-                   result  = as.double(double(npts)))
+                   result  = as.double(double(npts)),
+                   PACKAGE = "spatstat")
           if(sorted) result[,j] <- zz$result else result[oo,j] <- zz$result
         }
       }
@@ -429,7 +435,8 @@ densitypointsEngine <- function(x, sigma, ...,
                  rmaxi   = as.double(cutoff),
                  detsigma = as.double(detSigma),
                  sinv    = as.double(flatSinv),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result 
       } else if(k == 1L) {
         # vector of weights
@@ -442,7 +449,8 @@ densitypointsEngine <- function(x, sigma, ...,
                  detsigma = as.double(detSigma),
                  sinv    = as.double(flatSinv),
                  weight  = as.double(wtsort),
-                 result   = as.double(double(npts)))
+                 result   = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result 
       } else {
         # matrix of weights
@@ -456,7 +464,8 @@ densitypointsEngine <- function(x, sigma, ...,
                    detsigma = as.double(detSigma),
                    sinv    = as.double(flatSinv),
                    weight  = as.double(wtsort[,j]),
-                   result  = as.double(double(npts)))
+                   result  = as.double(double(npts)),
+                   PACKAGE = "spatstat")
           if(sorted) result[,j] <- zz$result else result[oo,j] <- zz$result 
         }
       }
@@ -716,7 +725,8 @@ densitycrossEngine <- function(Xdata, Xquery, sigma, ...,
                yd      = as.double(yd),
                rmaxi   = as.double(cutoff),
                sig     = as.double(sd),
-               result  = as.double(double(nquery)))
+               result  = as.double(double(nquery)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[ooq] <- zz$result 
     } else if(k == 1L) {
       wtsort <- if(sorted) weights else weights[ood]
@@ -730,7 +740,8 @@ densitycrossEngine <- function(Xdata, Xquery, sigma, ...,
                wd      = as.double(wtsort),
                rmaxi   = as.double(cutoff),
                sig     = as.double(sd),
-               result  = as.double(double(nquery)))
+               result  = as.double(double(nquery)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[ooq] <- zz$result 
     } else {
       ## matrix of weights
@@ -746,7 +757,8 @@ densitycrossEngine <- function(Xdata, Xquery, sigma, ...,
                  wd      = as.double(wtsort[,j]),
                  rmaxi   = as.double(cutoff),
                  sig     = as.double(sd),
-                 result  = as.double(double(nquery)))
+                 result  = as.double(double(nquery)),
+                 PACKAGE = "spatstat")
         if(sorted) result[,j] <- zz$result else result[ooq,j] <- zz$result
       }
       colnames(result) <- weightnames
@@ -765,7 +777,8 @@ densitycrossEngine <- function(Xdata, Xquery, sigma, ...,
                rmaxi   = as.double(cutoff),
                detsigma = as.double(detSigma),
                sinv    = as.double(flatSinv),
-               result  = as.double(double(nquery)))
+               result  = as.double(double(nquery)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[ooq] <- zz$result 
     } else if(k == 1L) {
       ## vector of weights
@@ -781,7 +794,8 @@ densitycrossEngine <- function(Xdata, Xquery, sigma, ...,
                rmaxi   = as.double(cutoff),
                detsigma = as.double(detSigma),
                sinv    = as.double(flatSinv),
-               result   = as.double(double(nquery)))
+               result   = as.double(double(nquery)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[ooq] <- zz$result 
     } else {
       ## matrix of weights
@@ -798,7 +812,8 @@ densitycrossEngine <- function(Xdata, Xquery, sigma, ...,
                  rmaxi   = as.double(cutoff),
                  detsigma = as.double(detSigma),
                  sinv    = as.double(flatSinv),
-                 result  = as.double(double(nquery)))
+                 result  = as.double(double(nquery)),
+                 PACKAGE = "spatstat")
         if(sorted) result[,j] <- zz$result else result[ooq,j] <- zz$result 
       }
       colnames(result) <- weightnames

--- a/R/density.psp.R
+++ b/R/density.psp.R
@@ -57,7 +57,8 @@ density.psp <- function(x, sigma, ..., edge=TRUE,
                    np = as.integer(np),
                    xp = as.double(xp), 
                    yp = as.double(yp),
-                   z = as.double(numeric(np)))
+                   z = as.double(numeric(np)),
+                   PACKAGE = "spatstat")
            dens <- im(z$z, w$xcol, w$yrow)
          },
          FFT = {

--- a/R/dg.R
+++ b/R/dg.R
@@ -35,7 +35,8 @@ DiggleGratton <- local({
               idtarget = as.integer(idYsort),
               ddelta   = as.double(delta),
               rrho     = as.double(rho),
-              values   = as.double(double(nX)))
+              values   = as.double(double(nX)),
+              PACKAGE = "spatstat")
     answer <- integer(nX)
     answer[oX] <- out$values
     return(answer)

--- a/R/dgs.R
+++ b/R/dgs.R
@@ -35,7 +35,8 @@ DiggleGatesStibbard <- local({
             ytarget  = as.double(Ysort$y),
             idtarget = as.integer(idYsort),
             rrho     = as.double(rho),
-            values   = as.double(double(nX)))
+            values   = as.double(double(nX)),
+            PACKAGE = "spatstat")
     answer <- integer(nX)
     answer[oX] <- out$values
     return(answer)

--- a/R/discarea.R
+++ b/R/discarea.R
@@ -44,7 +44,8 @@ discpartarea <- function(X, r, W=as.owin(X)) {
           x1=as.double(Y$ends$x1),
           y1=as.double(Y$ends$y1),
           eps=as.double(.Machine$double.eps),
-          out=as.double(numeric(length(r))))
+          out=as.double(numeric(length(r))),
+          PACKAGE = "spatstat")
   areas <- matrix(z$out, n, nr)
   return(areas)
 }

--- a/R/dist2dpath.R
+++ b/R/dist2dpath.R
@@ -52,7 +52,8 @@ dist2dpath <- function(dist, method="C") {
                    dpath=as.double(numeric(n*n)),
                    tol=as.double(tol),
                    niter=as.integer(integer(1L)),
-                   status=as.integer(integer(1L)))
+                   status=as.integer(integer(1L)),
+                   PACKAGE = "spatstat")
            if(z$status == -1L)
              warning(paste("C algorithm did not converge to tolerance", tol,
                            "after", z$niter, "iterations",

--- a/R/distan3D.R
+++ b/R/distan3D.R
@@ -30,7 +30,8 @@ pairdist.pp3 <- function(X, ..., periodic=FALSE, squared=FALSE) {
                y = as.double(y),
                z = as.double(z),
                squared = as.integer(squared),
-               d = as.double(numeric(n*n)))
+               d = as.double(numeric(n*n)),
+               PACKAGE = "spatstat")
   } else {
     b <- as.box3(X)
     wide <- diff(b$xrange)
@@ -45,7 +46,8 @@ pairdist.pp3 <- function(X, ..., periodic=FALSE, squared=FALSE) {
                yheight=as.double(high),
                zdepth=as.double(deep),
                squared = as.integer(squared),
-               d= as.double(numeric(n*n)))
+               d= as.double(numeric(n*n)),
+               PACKAGE = "spatstat")
   }
   dout <- matrix(Cout$d, nrow=n, ncol=n)
   return(dout)
@@ -106,7 +108,8 @@ nndist.pp3 <- function(X, ..., k=1) {
                z= as.double(z[o]),
                nnd= as.double(nnd),
                nnwhich = as.integer(integer(1L)),
-               huge=as.double(big))
+               huge=as.double(big),
+               PACKAGE = "spatstat")
     nnd[o] <- Cout$nnd
   } else {
     # case kmaxcalc > 1
@@ -121,7 +124,8 @@ nndist.pp3 <- function(X, ..., k=1) {
                z    = as.double(z[o]),
                nnd  = as.double(nnd),
                nnwhich = as.integer(integer(1L)),
-               huge = as.double(big))
+               huge = as.double(big),
+               PACKAGE = "spatstat")
     nnd <- matrix(nnd, nrow=n, ncol=kmaxcalc)
     nnd[o, ] <- matrix(Cout$nnd, nrow=n, ncol=kmaxcalc, byrow=TRUE)
   }
@@ -195,7 +199,8 @@ nnwhich.pp3 <- function(X, ..., k=1) {
                z = as.double(z[o]),
                nnd = as.double(numeric(1L)),
                nnwhich = as.integer(nnw),
-               huge = as.double(big))
+               huge = as.double(big),
+               PACKAGE = "spatstat")
     # [sic] Conversion from C to R indexing is done in C code.
     witch <- Cout$nnwhich
     if(any(witch <= 0))
@@ -216,7 +221,8 @@ nnwhich.pp3 <- function(X, ..., k=1) {
                z = as.double(z[o]),
                nnd = as.double(numeric(1L)),
                nnwhich = as.integer(nnw),
-               huge = as.double(big))
+               huge = as.double(big),
+               PACKAGE = "spatstat")
     # [sic] Conversion from C to R indexing is done in C code.
     witch <- Cout$nnwhich 
     witch <- matrix(witch, nrow=n, ncol=kmaxcalc, byrow=TRUE)
@@ -265,7 +271,8 @@ crossdist.pp3 <- function(X, Y, ..., periodic=FALSE, squared=FALSE) {
                yto = as.double(cY$y),
                zto = as.double(cY$z),
                squared = as.integer(squared),
-               d = as.double(matrix(0, nrow=nX, ncol=nY)))
+               d = as.double(matrix(0, nrow=nX, ncol=nY)),
+               PACKAGE = "spatstat")
   } else {
     b <- as.box3(X)
     wide <- diff(b$xrange)
@@ -284,7 +291,8 @@ crossdist.pp3 <- function(X, Y, ..., periodic=FALSE, squared=FALSE) {
                yheight = as.double(high),
                zheight = as.double(deep),
                squared = as.integer(squared),
-               d = as.double(matrix(0, nrow=nX, ncol=nY)))
+               d = as.double(matrix(0, nrow=nX, ncol=nY)),
+               PACKAGE = "spatstat")
   }
   return(matrix(Cout$d, nrow=nX, ncol=nY))
 }

--- a/R/distances.R
+++ b/R/distances.R
@@ -80,7 +80,8 @@ pairdist.default <-
                       x= as.double(x),
                       y= as.double(y),
                       squared=as.integer(squared),
-                      d= as.double(d))
+                      d= as.double(d),
+                      PACKAGE = "spatstat")
            } else {
              z <- .C("CpairPdist",
                      n = as.integer(n),
@@ -89,7 +90,8 @@ pairdist.default <-
                      xwidth=as.double(wide),
                      yheight=as.double(high),
                      squared = as.integer(squared),
-                     d= as.double(d))
+                     d= as.double(d),
+                     PACKAGE = "spatstat")
            }
            dout <- matrix(z$d, nrow=n, ncol=n)
          },
@@ -177,7 +179,8 @@ crossdist.default <-
                           xto = as.double(x2),
                           yto = as.double(y2),
                           squared = as.integer(squared),
-                          d = as.double(matrix(0, nrow=n1, ncol=n2)))
+                          d = as.double(matrix(0, nrow=n1, ncol=n2)),
+                          PACKAGE = "spatstat")
                  } else {
                    z<- .C("CcrossPdist",
                           nfrom = as.integer(n1),
@@ -189,7 +192,8 @@ crossdist.default <-
                           xwidth = as.double(wide),
                           yheight = as.double(high),
                           squared = as.integer(squared),
-                          d = as.double(matrix(0, nrow=n1, ncol=n2)))
+                          d = as.double(matrix(0, nrow=n1, ncol=n2)),
+                          PACKAGE = "spatstat")
                  }
                  return(matrix(z$d, nrow=n1, ncol=n2))
                },

--- a/R/distanxD.R
+++ b/R/distanxD.R
@@ -90,7 +90,8 @@ nndist.ppx <- function(X, ..., k=1) {
                m=as.integer(m),
                x= as.double(t(coo[o,])),
                nnd= as.double(nnd),
-               as.double(big))
+               as.double(big),
+               PACKAGE = "spatstat")
     nnd[o] <- Cout$nnd
   } else {
     # case kmaxcalc > 1
@@ -103,7 +104,8 @@ nndist.ppx <- function(X, ..., k=1) {
                kmax = as.integer(kmaxcalc),
                x    = as.double(t(coo[o,])),
                nnd  = as.double(nnd),
-               huge = as.double(big))
+               huge = as.double(big),
+               PACKAGE = "spatstat")
     nnd <- matrix(nnd, nrow=n, ncol=kmaxcalc)
     nnd[o, ] <- matrix(Cout$nnd, nrow=n, ncol=kmaxcalc, byrow=TRUE)
   }
@@ -177,7 +179,8 @@ nnwhich.ppx <- function(X, ..., k=1) {
                x = as.double(t(coo[o,])),
                nnd = as.double(numeric(n)),
                nnwhich = as.integer(nnw),
-               huge = as.double(big))
+               huge = as.double(big),
+               PACKAGE = "spatstat")
     witch <- Cout$nnwhich
     if(any(witch <= 0))
       stop("Internal error: non-positive index returned from C code")
@@ -196,7 +199,8 @@ nnwhich.ppx <- function(X, ..., k=1) {
                x = as.double(t(coo[o,])),
                nnd = as.double(numeric(n * kmaxcalc)),
                nnwhich = as.integer(nnw),
-               huge = as.double(big))
+               huge = as.double(big),
+               PACKAGE = "spatstat")
     witch <- Cout$nnwhich
     witch <- matrix(witch, nrow=n, ncol=kmaxcalc, byrow=TRUE)
     if(any(witch <= 0))

--- a/R/distmap.R
+++ b/R/distmap.R
@@ -84,7 +84,8 @@ distmap.owin <- function(X, ..., discretise=FALSE, invert=FALSE) {
               nc = as.integer(nc),
               inp = as.integer(as.logical(t(mat))),
               distances = as.double(matrix(0, ncol = nc + 2, nrow = nr + 2)),
-              boundary = as.double(matrix(0, ncol = nc + 2, nrow = nr + 2)))
+              boundary = as.double(matrix(0, ncol = nc + 2, nrow = nr + 2)),
+              PACKAGE = "spatstat")
   # strip off margins again
     dist <- matrix(res$distances,
                    ncol = nc + 2, byrow = TRUE)[2:(nr + 1), 2:(nc +1)]

--- a/R/edgeRipley.R
+++ b/R/edgeRipley.R
@@ -138,7 +138,8 @@ edge.Ripley <- local({
                               xmax=as.double(W$xrange[2L]),
                               ymax=as.double(W$yrange[2L]),
                               epsilon=as.double(.Machine$double.eps),
-                              out=as.double(numeric(Nr * Nc)))
+                              out=as.double(numeric(Nr * Nc)),
+                              PACKAGE = "spatstat")
                       weight <- matrix(z$out, nrow=Nr, ncol=Nc)
                     },
                     polygonal={
@@ -154,7 +155,8 @@ edge.Ripley <- local({
                               y0=as.double(Y$ends$y0),
                               x1=as.double(Y$ends$x1),
                               y1=as.double(Y$ends$y1),
-                              out=as.double(numeric(Nr * Nc)))
+                              out=as.double(numeric(Nr * Nc)),
+                              PACKAGE = "spatstat")
                       angles <- matrix(z$out, nrow = Nr, ncol = Nc)
                       weight <- 2 * pi/angles
                     }

--- a/R/edges2triangles.R
+++ b/R/edges2triangles.R
@@ -31,14 +31,14 @@ edges2triangles <- function(iedge, jedge, nvert=max(iedge, jedge),
   storage.mode(nvert) <- storage.mode(iedge) <- storage.mode(jedge) <- "integer"
   if(!usefriends) {
     zz <- .Call("triograph",
-                nv=nvert, iedge=iedge, jedge=jedge)
-#                PACKAGE="spatstat")
+                nv=nvert, iedge=iedge, jedge=jedge,
+                PACKAGE="spatstat")
   } else {
     fr <- as.logical(friendly)
     storage.mode(fr) <- "integer"
     zz <- .Call("trioxgraph",
-                nv=nvert, iedge=iedge, jedge=jedge, friendly=fr)
-#                PACKAGE="spatstat")
+                nv=nvert, iedge=iedge, jedge=jedge, friendly=fr,
+                PACKAGE="spatstat")
   }
   mat <- as.matrix(as.data.frame(zz))
   return(mat)
@@ -72,12 +72,14 @@ trianglediameters <- function(iedge, jedge, edgelength, ...,
   storage.mode(edgelength) <- "double"
   if(is.infinite(dmax)) {
     zz <- .Call("triDgraph",
-                nv=nvert, iedge=iedge, jedge=jedge, edgelength=edgelength)
+                nv=nvert, iedge=iedge, jedge=jedge, edgelength=edgelength,
+                PACKAGE = "spatstat")
   } else {
     storage.mode(dmax) <- "double"
     zz <- .Call("triDRgraph",
                 nv=nvert, iedge=iedge, jedge=jedge, edgelength=edgelength,
-                dmax=dmax)
+                dmax=dmax,
+                PACKAGE = "spatstat")
   }    
   df <- as.data.frame(zz)
   colnames(df) <- c("i", "j", "k", "diam")
@@ -112,8 +114,8 @@ edges2vees <- function(iedge, jedge, nvert=max(iedge, jedge),
   vees <- .Call("graphVees",
                 nv = nvert,
                 iedge = iedge,
-                jedge = jedge)
-#                PACKAGE="spatstat")
+                jedge = jedge,
+                PACKAGE="spatstat")
   names(vees) <- c("i", "j", "k")
   vees <- as.data.frame(vees)
   return(vees)

--- a/R/exactPdt.R
+++ b/R/exactPdt.R
@@ -42,7 +42,8 @@
             distances = as.double (double(N)),
             rows      = as.integer(integer(N)),
             cols      = as.integer(integer(N)),
-            boundary  = as.double (double(N)))
+            boundary  = as.double (double(N)),
+            PACKAGE = "spatstat")
   dist <- matrix(res$distances,
                  ncol=Nnc, nrow=Nnr, byrow = TRUE)[rmin:rmax, cmin:cmax]
   rows <- matrix(res$rows,

--- a/R/exactdt.R
+++ b/R/exactdt.R
@@ -56,7 +56,8 @@ exactdt <- local({
               mc = as.integer(mc),
               distances = as.double(double(N)),
               indices = as.integer(integer(N)),
-              boundary = as.double(double(N)))
+              boundary = as.double(double(N)),
+              PACKAGE = "spatstat")
     ## extract 
     dist <- matrix(res$distances,
                    ncol=Nnc, nrow=Nnr, byrow = TRUE)[rmin:rmax, cmin:cmax]

--- a/R/fardist.R
+++ b/R/fardist.R
@@ -30,7 +30,8 @@ fardist.owin <- function(X, ..., squared=FALSE) {
             np = as.integer(length(V$x)),
             xp = as.double(V$x),
             yp = as.double(V$y),
-            dfar = as.double(numeric(nx * ny)))
+            dfar = as.double(numeric(nx * ny)),
+            PACKAGE = "spatstat")
   } else {
     z <- .C("fardistgrid",
             nx = as.integer(nx),
@@ -42,7 +43,8 @@ fardist.owin <- function(X, ..., squared=FALSE) {
             np = as.integer(length(V$x)),
             xp = as.double(V$x),
             yp = as.double(V$y),
-            dfar = as.double(numeric(nx * ny)))
+            dfar = as.double(numeric(nx * ny)),
+            PACKAGE = "spatstat")
   }
   out <- im(z$dfar, xcol=M$xcol, yrow=M$yrow,
             xrange=M$xrange, yrange=M$yrange, unitname=unitname(M))

--- a/R/fgk3.R
+++ b/R/fgk3.R
@@ -298,7 +298,8 @@ k3engine <- function(x, y, z, box=c(0,1,0,1,0,1),
             f = as.double(numeric(nrval)),
             num = as.double(numeric(nrval)),
             denom = as.double(numeric(nrval)),
-            as.integer(code))
+            as.integer(code),
+            PACKAGE = "spatstat")
   return(list(range = c(0,rmax),
               f = res$f, num=res$num, denom=res$denom, 
               correction=correction))
@@ -321,7 +322,8 @@ g3engine <- function(x, y, z, box=c(0,1,0,1,0,1),
 		f = as.double(numeric(nrval)),
 		num = as.double(numeric(nrval)),
 		denom = as.double(numeric(nrval)),
-		as.integer(code))
+		as.integer(code),
+	  PACKAGE = "spatstat")
 	return(list(range = range, f = res$f, num=res$num, denom=res$denom, 
 		correction=correction))
 }
@@ -345,7 +347,8 @@ f3engine <- function(x, y, z, box=c(0,1,0,1,0,1),
 		m=as.integer(nval),
 		num = as.integer(integer(nval)),
 		denom = as.integer(integer(nval)),
-		as.integer(code))
+		as.integer(code),
+	  PACKAGE = "spatstat")
 	r <- seq(from=range[1L], to=range[2L], length.out=nval)
 	f <- with(res, ifelseXB(denom > 0, num/denom, 1))
 
@@ -371,7 +374,8 @@ f3Cengine <- function(x, y, z, box=c(0,1,0,1,0,1),
             cen = as.integer(integer(nrval)),
             ncc = as.integer(integer(nrval)),
             upperobs = as.integer(integer(1L)),
-            uppercen = as.integer(integer(1L)))
+            uppercen = as.integer(integer(1L)),
+            PACKAGE = "spatstat")
   r <- seq(from=0, to=rmax, length.out=nrval)
   #
   obs <- res$obs
@@ -409,7 +413,8 @@ g3Cengine <- function(x, y, z, box=c(0,1,0,1,0,1),
             cen = as.integer(integer(nrval)),
             ncc = as.integer(integer(nrval)),
             upperobs = as.integer(integer(1L)),
-            uppercen = as.integer(integer(1L)))
+            uppercen = as.integer(integer(1L)),
+            PACKAGE = "spatstat")
   r <- seq(from=0, to=rmax, length.out=nrval)
   #
   obs <- res$obs
@@ -446,7 +451,8 @@ pcf3engine <- function(x, y, z, box=c(0,1,0,1,0,1),
             num = as.double(numeric(nrval)),
             denom = as.double(numeric(nrval)),
             method=as.integer(code),
-            delta=as.double(delta))
+            delta=as.double(delta),
+            PACKAGE = "spatstat")
 	return(list(range = c(0,rmax),
                     f = res$f, num=res$num, denom=res$denom, 
                     correction=correction))
@@ -483,7 +489,8 @@ digital.volume <- function(range=c(0, 1.414),  nval=25, vside= 0.05)
                    as.integer(nval),
                    num = as.integer(integer(nval)),
                    denom = as.integer(integer(nval)),
-                   as.integer(0))$num
+                   as.integer(0),
+	                 PACKAGE = "spatstat")$num
 #	
         (vside^3) * dvol 
       }

--- a/R/fiksel.R
+++ b/R/fiksel.R
@@ -45,7 +45,8 @@ Fiksel <- local({
             ytarget  = as.double(Ysort$y),
             rrmax    = as.double(r),
             kkappa   = as.double(kappa),
-            values   = as.double(double(nX)))
+            values   = as.double(double(nX)),
+            PACKAGE = "spatstat")
     answer <- integer(nX)
     answer[oX] <- out$values
     return(answer)

--- a/R/geyer.R
+++ b/R/geyer.R
@@ -222,7 +222,8 @@ geyercounts <- function(U, X, r, sat, Xcounts, EqualPairs) {
            tdata  = as.integer(Xcountsort),
            rrmax  = as.double(r),
            ssat   = as.double(sat),
-           result = as.double(numeric(nU)))
+           result = as.double(numeric(nU)),
+           PACKAGE = "spatstat")
   result <- zz$result[rankU]
   return(result)
 }

--- a/R/hasclose.R
+++ b/R/hasclose.R
@@ -42,7 +42,8 @@ has.close.ppp <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                x = as.double(cX$x),
                y = as.double(cX$y),
                r = as.double(r),
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     } else {
       b <- sidelengths(Frame(X))
       zz <- .C("hasXpclose",
@@ -51,7 +52,8 @@ has.close.ppp <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                y = as.double(cX$y),
                r = as.double(r),
                b = as.double(b),
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     }
   } else {
     stopifnot(is.ppp(Y))
@@ -72,7 +74,8 @@ has.close.ppp <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                x2 = as.double(cY$x),
                y2 = as.double(cY$y),
                r = as.double(r),
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     } else {
       bX <- sidelengths(Frame(X))
       bY <- sidelengths(Frame(Y))
@@ -87,7 +90,8 @@ has.close.ppp <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                y2 = as.double(cY$y),
                r = as.double(r),
                b = as.double(bX),
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     }
   }
   tt <- as.logical(zz$t)
@@ -116,7 +120,8 @@ has.close.pp3 <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                y = as.double(cX$y),
                z = as.double(cX$z),
                r = as.double(r),
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     } else {
       b <- sidelengths(as.box3(X))
       zz <- .C("hasX3pclose",
@@ -126,7 +131,8 @@ has.close.pp3 <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                z = as.double(cX$z),
                r = as.double(r),
                b = as.double(b), 
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     }
   } else {
     stopifnot(is.pp3(Y))
@@ -149,7 +155,8 @@ has.close.pp3 <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                y2 = as.double(cY$y),
                z2 = as.double(cY$z),
                r = as.double(r),
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     } else {
       bX <- sidelengths(as.box3(X))
       bY <- sidelengths(as.box3(Y))
@@ -166,7 +173,8 @@ has.close.pp3 <- function(X, r, Y=NULL, ..., periodic=FALSE, sorted=FALSE) {
                z2 = as.double(cY$z),
                r = as.double(r),
                b = as.double(bX),
-               t = as.integer(integer(nX)))
+               t = as.integer(integer(nX)),
+               PACKAGE = "spatstat")
     }
   }
   tt <- as.logical(zz$t)

--- a/R/idw.R
+++ b/R/idw.R
@@ -46,7 +46,8 @@ idw <- function(X, power=2, at="pixels", ...) {
                    power  = as.double(power),
                    num    = as.double(numeric(npixels)),
                    den    = as.double(numeric(npixels)),
-                   rat    = as.double(numeric(npixels)))
+                   rat    = as.double(numeric(npixels)),
+                   PACKAGE = "spatstat")
            out <- as.im(matrix(z$rat, dim[1L], dim[2L]), W=W)
            out <- out[W, drop=FALSE]
          },
@@ -60,7 +61,8 @@ idw <- function(X, power=2, at="pixels", ...) {
                    power  = as.double(power),
                    num    = as.double(numeric(npts)),
                    den    = as.double(numeric(npts)),
-                   rat    = as.double(numeric(npts)))
+                   rat    = as.double(numeric(npts)),
+                   PACKAGE = "spatstat")
            out <- z$rat
          })
   return(out)

--- a/R/linalg.R
+++ b/R/linalg.R
@@ -42,14 +42,16 @@ sumouter <- function(x, w=NULL, y=x) {
                x=as.double(tx),
                n=as.integer(n),
                p=as.integer(p),
-               y=as.double(numeric(p * p)))
+               y=as.double(numeric(p * p)),
+               PACKAGE = "spatstat")
     } else {
       zz <- .C("Cwsumouter",
                x=as.double(tx),
                n=as.integer(n),
                p=as.integer(p),
                w=as.double(w),
-               y=as.double(numeric(p * p)))
+               y=as.double(numeric(p * p)),
+               PACKAGE = "spatstat")
     }
     out <- matrix(zz$y, p, p)
     if(!is.null(nama <- colnames(x)))
@@ -65,7 +67,8 @@ sumouter <- function(x, w=NULL, y=x) {
                n=as.integer(n),
                px=as.integer(px),
                py=as.integer(py),
-               z=as.double(numeric(px * py)))
+               z=as.double(numeric(px * py)),
+               PACKAGE = "spatstat")
     } else {
       zz <- .C("Cwsum2outer",
                x=as.double(tx),
@@ -111,7 +114,8 @@ quadform <- function(x, v) {
           n=as.integer(n),
           p=as.integer(p),
           v=as.double(v),
-          y=as.double(numeric(n)))
+          y=as.double(numeric(n)),
+          PACKAGE = "spatstat")
   result <- z$y
   names(result) <- nama[ok]
   if(allok)
@@ -153,7 +157,8 @@ bilinearform <- function(x, v, y) {
           n=as.integer(n),
           p=as.integer(p),
           v=as.double(v),
-          z=as.double(numeric(n)))
+          z=as.double(numeric(n)),
+          PACKAGE = "spatstat")
   result <- z$z
   names(result) <- nama[ok]
   if(allok)
@@ -187,14 +192,16 @@ sumsymouter <- function(x, w=NULL) {
              x = as.double(x),
              p = as.integer(p),
              n = as.integer(n),
-             y = as.double(numeric(p * p)))
+             y = as.double(numeric(p * p)),
+             PACKAGE = "spatstat")
   } else {
     zz <- .C("Cwsumsymouter",
              x = as.double(x),
              w = as.double(w),
              p = as.integer(p),
              n = as.integer(n),
-             y = as.double(numeric(p * p)))
+             y = as.double(numeric(p * p)),
+             PACKAGE = "spatstat")
   }
   matrix(zz$y, p, p)
 }

--- a/R/lineardisc.R
+++ b/R/lineardisc.R
@@ -204,7 +204,8 @@ countends <- function(L, x=locator(1), r, toler=NULL) {
            dpath = as.double(dpath),
            lengths = as.double(lengths),
            toler=as.double(toler),
-           nendpoints = as.integer(integer(np)))
+           nendpoints = as.integer(integer(np)),
+           PACKAGE = "spatstat")
   zz$nendpoints
 }
 

--- a/R/linequad.R
+++ b/R/linequad.R
@@ -76,7 +76,8 @@ linequad <- function(X, Y, ..., eps=NULL, nd=1000, random=FALSE) {
                 sdum  = as.integer(integer(ndummax)),
                 tdum  = as.double(numeric(ndummax)),
                 wdum  = as.double(numeric(ndummax)),
-                maxscratch = as.integer(maxscratch))
+                maxscratch = as.integer(maxscratch),
+                PACKAGE = "spatstat")
       } else {
         z <- .C("ClineRquad",
                 ns    = as.integer(nseg),
@@ -96,7 +97,8 @@ linequad <- function(X, Y, ..., eps=NULL, nd=1000, random=FALSE) {
                 sdum  = as.integer(integer(ndummax)),
                 tdum  = as.double(numeric(ndummax)),
                 wdum  = as.double(numeric(ndummax)),
-                maxscratch = as.integer(maxscratch))
+                maxscratch = as.integer(maxscratch),
+                PACKAGE = "spatstat")
       }
       seqdum <- seq_len(z$ndum)
       dum <- with(z, ppp(xdum[seqdum], ydum[seqdum], window=W, check=FALSE))
@@ -132,7 +134,8 @@ linequad <- function(X, Y, ..., eps=NULL, nd=1000, random=FALSE) {
                 sdum  = as.integer(integer(ndummax)),
                 tdum  = as.double(numeric(ndummax)),
                 wdum  = as.double(numeric(ndummax)),
-                maxscratch = as.integer(maxscratch))
+                maxscratch = as.integer(maxscratch),
+                PACKAGE = "spatstat")
       } else {
         z <- .C("ClineRMquad",
                 ns    = as.integer(nseg),
@@ -157,7 +160,8 @@ linequad <- function(X, Y, ..., eps=NULL, nd=1000, random=FALSE) {
                 sdum  = as.integer(integer(ndummax)),
                 tdum  = as.double(numeric(ndummax)),
                 wdum  = as.double(numeric(ndummax)),
-                maxscratch = as.integer(maxscratch))
+                maxscratch = as.integer(maxscratch),
+                PACKAGE = "spatstat")
       }
       seqdum <- seq_len(z$ndum)
       marques <- factor(z$mdum[seqdum] + 1L, labels=flev)

--- a/R/linnet.R
+++ b/R/linnet.R
@@ -363,8 +363,8 @@ boundingradius.linnet <- function(x, ...) {
             nv = as.integer(nv), 
             dpath = as.double(dpath), 
             huge = as.double(huge), 
-            result = as.double(numeric(1))
-            )
+            result = as.double(numeric(1)),
+            PACKAGE = "spatstat")
     return(z$result)
   }
   sA <- sB <- matrix(Inf, nseg, nseg)
@@ -553,7 +553,8 @@ connected.linnet <- function(X, ..., what=c("labels", "components")) {
            ie = as.integer(ie),
            je = as.integer(je),
            label = as.integer(integer(nv)), 
-           status = as.integer(integer(1L)))
+           status = as.integer(integer(1L)),
+           PACKAGE = "spatstat")
   if (zz$status != 0) 
     stop("Internal error: connected.linnet did not converge")
   lab <- zz$label + 1L

--- a/R/lintess.R
+++ b/R/lintess.R
@@ -189,7 +189,8 @@ divide.linnet <- local({
              ie = as.integer(iedge - 1L),
              je = as.integer(jedge - 1L),
              label = as.integer(integer(nbits)), 
-             status = as.integer(integer(1L)))
+             status = as.integer(integer(1L)),
+             PACKAGE = "spatstat")
     if (zz$status != 0) 
       stop("Internal error: connectedness algorithm did not converge")
     lab <- zz$label + 1L

--- a/R/lixellate.R
+++ b/R/lixellate.R
@@ -76,7 +76,8 @@ lixellate <- function(X, ..., nsplit, eps, sparse=TRUE) {
           spcoarse = as.integer(sp[oo]-1L),
           tpcoarse = as.double(tp[oo]),
           spfine = as.integer(integer(np)),
-          tpfine = as.double(numeric(np)))
+          tpfine = as.double(numeric(np)),
+          PACKAGE = "spatstat")
 
   Lfine <- with(z, {
     ii <- seq_len(nv)

--- a/R/localpcf.R
+++ b/R/localpcf.R
@@ -131,7 +131,8 @@ localpcfmatrix <- function(X, i=seq_len(npoints(X)), ...,
                nnr = as.integer(nr),
                rmaxi=as.double(rmax),
                del=as.double(delta),
-               pcf=as.double(double(nr * nY)))
+               pcf=as.double(double(nr * nY)),
+               PACKAGE = "spatstat")
     } else {
       zz <- .C("locWpcfx",
                nn1 = as.integer(nY),
@@ -146,7 +147,8 @@ localpcfmatrix <- function(X, i=seq_len(npoints(X)), ...,
                nnr = as.integer(nr),
                rmaxi=as.double(rmax),
                del=as.double(delta),
-               pcf=as.double(double(nr * nY)))
+               pcf=as.double(double(nr * nY)),
+               PACKAGE = "spatstat")
     }
     out <- matrix(zz$pcf, nr, nY)
     # reorder columns to match original

--- a/R/minnndist.R
+++ b/R/minnndist.R
@@ -19,14 +19,16 @@ minnndist <- function(X, positive=FALSE) {
               x = as.double(x[o]),
               y = as.double(y[o]),
               as.double(big),
-              result = as.double(numeric(1)))
+              result = as.double(numeric(1)),
+              PACKAGE = "spatstat")
   } else {
       z <- .C("minnnd2",
               n = as.integer(n),
               x = as.double(x[o]),
               y = as.double(y[o]),
               as.double(big),
-              result = as.double(numeric(1)))
+              result = as.double(numeric(1)),
+              PACKAGE = "spatstat")
   }
   return(sqrt(z$result))
 }
@@ -45,14 +47,16 @@ maxnndist <- function(X, positive=FALSE) {
               x = as.double(x[o]),
               y = as.double(y[o]),
               as.double(big),
-              result = as.double(numeric(1)))
+              result = as.double(numeric(1)),
+              PACKAGE = "spatstat")
   } else {
       z <- .C("maxnnd2",
               n = as.integer(n),
               x = as.double(x[o]),
               y = as.double(y[o]),
               as.double(big),
-              result = as.double(numeric(1)))
+              result = as.double(numeric(1)),
+              PACKAGE = "spatstat")
   }
   return(sqrt(z$result))
 }

--- a/R/nncross.R
+++ b/R/nncross.R
@@ -147,7 +147,8 @@ nncross.ppp <- function(X, Y, iX=NULL, iY=NULL,
             wantwhich = as.integer(want.which),
             nnd=as.double(nndv),
             nnwhich=as.integer(nnwh),
-            huge=as.double(huge))
+            huge=as.double(huge),
+            PACKAGE = "spatstat")
 
     if(want.which) {
       nnwcode <- z$nnwhich #sic. C code now increments by 1
@@ -193,7 +194,8 @@ nncross.ppp <- function(X, Y, iX=NULL, iY=NULL,
             wantwhich = as.integer(want.which),
             nnd=as.double(nndv),
             nnwhich=as.integer(nnwh),
-            huge=as.double(huge))
+            huge=as.double(huge),
+            PACKAGE = "spatstat")
 
     # extract results
     nnD <- z$nnd

--- a/R/nncross3D.R
+++ b/R/nncross3D.R
@@ -135,7 +135,8 @@ nncross.pp3 <- function(X, Y, iX=NULL, iY=NULL,
             wantwhich = as.integer(want.which),
             nnd=as.double(nndv),
             nnwhich=as.integer(nnwh),
-            huge=as.double(huge))
+            huge=as.double(huge),
+            PACKAGE = "spatstat")
 
     if(want.which) {
       # conversion to R indexing is done in C code
@@ -183,7 +184,8 @@ nncross.pp3 <- function(X, Y, iX=NULL, iY=NULL,
             wantwhich = as.integer(want.which),
             nnd=as.double(nndv),
             nnwhich=as.integer(nnwh),
-            huge=as.double(huge))
+            huge=as.double(huge),
+            PACKAGE = "spatstat")
 
     # extract results
     nnD <- z$nnd

--- a/R/nndist.R
+++ b/R/nndist.R
@@ -107,7 +107,8 @@ nndist.default <-
            z<- .C("nndistsort",
                   n= as.integer(n),
                   x= as.double(x[o]), y= as.double(y[o]), nnd= as.double(nnd),
-                  as.double(big))
+                  as.double(big),
+                  PACKAGE = "spatstat")
            nnd[o] <- z$nnd
          },
          stop(paste("Unrecognised method", sQuote(method)))
@@ -145,7 +146,8 @@ nndist.default <-
                     x    = as.double(x[o]),
                     y    = as.double(y[o]),
                     nnd  = as.double(nnd),
-                    huge = as.double(big))
+                    huge = as.double(big),
+                    PACKAGE = "spatstat")
              nnd <- matrix(nnd, nrow=n, ncol=kmaxcalc)
              nnd[o, ] <- matrix(z$nnd, nrow=n, ncol=kmaxcalc, byrow=TRUE)
            },
@@ -287,7 +289,8 @@ nnwhich.default <-
                     x = as.double(x[o]),
                     y = as.double(y[o]),
                     nnwhich = as.integer(nnw),
-                    huge = as.double(big))
+                    huge = as.double(big),
+                    PACKAGE = "spatstat")
              witch <- z$nnwhich # sic 
              if(any(witch <= 0))
                stop("Internal error: non-positive index returned from C code")
@@ -329,7 +332,8 @@ nnwhich.default <-
                     y = as.double(y[o]),
                     nnd = as.double(numeric(n * kmaxcalc)),
                     nnwhich = as.integer(nnw),
-                    huge = as.double(big))
+                    huge = as.double(big),
+                    PACKAGE = "spatstat")
              witch <- z$nnwhich # sic
              witch <- matrix(witch, nrow=n, ncol=kmaxcalc, byrow=TRUE)
              if(any(witch <= 0))

--- a/R/nndistlpp.R
+++ b/R/nndistlpp.R
@@ -75,7 +75,8 @@ nndist.lpp <- function(X, ..., k=1, method="C") {
              dpath = as.double(dpath),
              segmap = as.integer(segmap),
              huge = as.double(huge),
-             answer = as.double(ans))
+             answer = as.double(ans),
+             PACKAGE = "spatstat")
     ans <- zz$answer
   } else if(spatstat.options('Cnndistlpp')) {
     ## use new C routine
@@ -115,7 +116,8 @@ nndist.lpp <- function(X, ..., k=1, method="C") {
              huge = as.double(huge),
              tol = as.double(tol),
              nndist = as.double(numeric(n * kmax1)),
-             nnwhich = as.integer(integer(n * kmax1)))
+             nnwhich = as.integer(integer(n * kmax1)),
+             PACKAGE = "spatstat")
     ans <- matrix(, n, kmax1)
     ans[oo, ] <- matrix(zz$nndist, n, kmax1, byrow=TRUE)
     # drop first column which is zero corresponding to j = i
@@ -214,7 +216,8 @@ nnwhich.lpp <- function(X, ..., k=1, method="C") {
              segmap = as.integer(segmap),
              huge = as.double(huge),
              nndist = as.double(nnd),
-             nnwhich = as.integer(nnw))
+             nnwhich = as.integer(nnw),
+             PACKAGE = "spatstat")
     # convert C indexing to R indexing
     nnw <- zz$nnwhich + 1L
     # any zeroes occur if points have no neighbours.
@@ -257,7 +260,8 @@ nnwhich.lpp <- function(X, ..., k=1, method="C") {
              huge = as.double(huge),
              tol = as.double(tol),
              nndist = as.double(numeric(n * kmax1)),
-             nnwhich = as.integer(integer(n * kmax1)))
+             nnwhich = as.integer(integer(n * kmax1)),
+             PACKAGE = "spatstat")
     nnw <- matrix(, n, kmax1)
     nnw[oo, ] <- matrix(oo[zz$nnwhich + 1L], n, kmax1, byrow=TRUE)
     # drop first column which is j = i
@@ -443,7 +447,8 @@ nncross.lpp <- local({
                  huge = as.double(huge),
                  tol = as.double(tol), 
                  nndist = as.double(nnd), 
-                 nnwhich = as.integer(nnw))
+                 nnwhich = as.integer(nnw),
+                 PACKAGE = "spatstat")
         zznd <- matrix(zz$nndist, ncol=kmax, byrow=TRUE)
         zznw <- matrix(zz$nnwhich + 1L, ncol=kmax, byrow=TRUE)
         if(any(notfound <- (zznw == 0))) {
@@ -479,7 +484,8 @@ nncross.lpp <- local({
                  huge = as.double(huge),
                  tol = as.double(tol), 
                  nndist = as.double(nnd),
-                 nnwhich = as.integer(nnw))
+                 nnwhich = as.integer(nnw),
+                 PACKAGE = "spatstat")
         zznd <- zz$nndist
         zznw <- zz$nnwhich + 1L
         if(any(notfound <- (zznw == 0))) {
@@ -508,7 +514,8 @@ nncross.lpp <- local({
                qsegmap = as.integer(Ysegmap),
                huge = as.double(huge),
                nndist = as.double(nnd),
-               nnwhich = as.integer(nnw))
+               nnwhich = as.integer(nnw),
+               PACKAGE = "spatstat")
       nnd <- zz$nndist
       nnw <- zz$nnwhich + 1L
     } else {
@@ -533,7 +540,8 @@ nncross.lpp <- local({
                idQ = as.integer(iY),
                huge = as.double(huge),
                nndist = as.double(nnd),
-               nnwhich = as.integer(nnw))
+               nnwhich = as.integer(nnw),
+               PACKAGE = "spatstat")
       nnd <- zz$nndist
       nnw <- zz$nnwhich + 1L
     }

--- a/R/nnmap.R
+++ b/R/nnmap.R
@@ -116,7 +116,8 @@ nnmap <- function(X, k=1, what = c("dist", "which"), ...,
                wantwhich = as.integer(want.which),
                nnd = as.double(nndv),
                nnwhich = as.integer(nnwh),
-               huge = as.double(huge))
+               huge = as.double(huge),
+               PACKAGE = "spatstat")
     } else {
       zz <- .C("knnGinterface",
                nx = as.integer(nxcol),
@@ -133,7 +134,8 @@ nnmap <- function(X, k=1, what = c("dist", "which"), ...,
                wantwhich = as.integer(want.which),
                nnd = as.double(nndv),
                nnwhich = as.integer(nnwh),
-               huge = as.double(huge))
+               huge = as.double(huge),
+               PACKAGE = "spatstat")
     }
     
     # extract results

--- a/R/pairdistlpp.R
+++ b/R/pairdistlpp.R
@@ -83,7 +83,8 @@ pairdist.lpp <- function(X, ..., method="C") {
              to = as.integer(to0),
              dpath = as.double(dpath),
              segmap = as.integer(segmap),
-             answer = as.double(pairdistmat))
+             answer = as.double(pairdistmat),
+             PACKAGE = "spatstat")
     pairdistmat <- matrix(zz$answer, n, n)
   }
   return(pairdistmat)

--- a/R/pixellate.R
+++ b/R/pixellate.R
@@ -210,7 +210,8 @@ polytileareaEngine <- function(P, xrange, yrange, nx, ny) {
              ypoly=as.double(yy),
              npoly=as.integer(nn),
              out=as.double(numeric(nx * ny)),
-             status=as.integer(integer(1L)))
+             status=as.integer(integer(1L)),
+             PACKAGE = "spatstat")
     if(zz$status != 0)
       stop("Internal error")
     # increment output 

--- a/R/polygood.R
+++ b/R/polygood.R
@@ -154,7 +154,8 @@ xypolyselfint <- function(p, eps=.Machine$double.eps,
                  ysep=as.double(2 * max(abs(dy))),
                  eps=as.double(eps),
                  proper=as.integer(proper),
-                 answer=as.integer(integer(1L)))$answer
+                 answer=as.integer(integer(1L)),
+                 PACKAGE = "spatstat")$answer
     if(verbose)
       cat("]\n")
     return(answer != 0)
@@ -170,7 +171,8 @@ xypolyselfint <- function(p, eps=.Machine$double.eps,
             yy=as.double(numeric(n^2)),
             ti=as.double(numeric(n^2)),
             tj=as.double(numeric(n^2)),
-            ok=as.integer(integer(n^2)))
+            ok=as.integer(integer(n^2)),
+            PACKAGE = "spatstat")
 
   uhoh <- (matrix(out$ok, n, n) != 0)
   if(proper) {

--- a/R/pppmatch.R
+++ b/R/pppmatch.R
@@ -439,7 +439,8 @@ pppdist <- function(X, Y, type = "spa", cutoff = 1, q = 1, matching = TRUE,
                     price = as.double(rep(0,n)),
                     profit = as.double(rep(0,n)),
                     as.integer(neps),
-                    as.double(epsvec))
+                    as.double(epsvec),
+  	                PACKAGE = "spatstat")
       am <- matrix(0, n, n)
       am[cbind(1:n,res$pers_to_obj+1)] <- 1
     }
@@ -450,7 +451,8 @@ pppdist <- function(X, Y, type = "spa", cutoff = 1, q = 1, matching = TRUE,
              as.integer(rep.int(1,n)),
              as.integer(n),
              as.integer(n),
-             flowmatrix = as.integer(integer(n^2)))
+             flowmatrix = as.integer(integer(n^2)),
+             PACKAGE = "spatstat")
       am <- matrix(res$flowmatrix, n, n)
     }
   }
@@ -675,7 +677,8 @@ pppdist.prohorov <- function(X, Y, n, dfix, type, cutoff = 1, matching = TRUE,
                       price = as.double(rep(0,n)),
                       profit = as.double(rep(0,n)),
                       as.integer(neps),
-                      as.double(epsvec))
+                      as.double(epsvec),
+  	                  PACKAGE = "spatstat")
         am <- matrix(0, n, n)
         am[cbind(1:n,res$pers_to_obj+1)] <- 1
       }
@@ -686,7 +689,8 @@ pppdist.prohorov <- function(X, Y, n, dfix, type, cutoff = 1, matching = TRUE,
                  as.integer(rep.int(1,n)),
                  as.integer(n),
                  as.integer(n),
-                 flowmatrix = as.integer(integer(n^2)))
+                 flowmatrix = as.integer(integer(n^2)),
+                 PACKAGE = "spatstat")
         am <- matrix(res$flowmatrix, n, n)
       }
     }
@@ -712,7 +716,8 @@ pppdist.prohorov <- function(X, Y, n, dfix, type, cutoff = 1, matching = TRUE,
     res <- .C("dinfty_R",
              as.integer(d),
              as.integer(n),
-             assignment = as.integer(rep.int(-1,n)))
+             assignment = as.integer(rep.int(-1,n)),
+             PACKAGE = "spatstat")
     assig <- res$assignment
     am <- matrix(0, n, n)
     am[cbind(1:n, assig[1:n])] <- 1
@@ -773,7 +778,8 @@ pppdist.mat <- function(X, Y, cutoff = 1, q = 1, matching = TRUE, precision = 9,
              as.integer(rep.int(mass2,n2)),
              as.integer(n1),
              as.integer(n2),
-             flowmatrix = as.integer(integer(n1*n2)))
+             flowmatrix = as.integer(integer(n1*n2)),
+             PACKAGE = "spatstat")
     am <- matrix(res$flowmatrix/(max(n1,n2)/gcd), n1, n2)
     resdist <- max(dfix[am > 0])
   }
@@ -799,7 +805,8 @@ pppdist.mat <- function(X, Y, cutoff = 1, q = 1, matching = TRUE, precision = 9,
              as.integer(rep.int(mass2,n2)),
              as.integer(n1),
              as.integer(n2),
-             flowmatrix = as.integer(integer(n1*n2)))
+             flowmatrix = as.integer(integer(n1*n2)),
+             PACKAGE = "spatstat")
     am <- matrix(res$flowmatrix/(max(n1,n2)/gcd), n1, n2)
     # our "adjacency matrix" in this case is standardized to have
     # rowsum 1 if n1 <= n2 and colsum 1 if n1 >= n2

--- a/R/psp2pix.R
+++ b/R/psp2pix.R
@@ -39,7 +39,8 @@ as.mask.psp <- function(x, W=NULL, ...) {
            y1=as.double(y1),
            nx=as.integer(nc),
            ny=as.integer(nr),
-           out=as.integer(integer(nr * nc)))
+           out=as.integer(integer(nr * nc)),
+           PACKAGE = "spatstat")
   mm <- matrix(zz$out, nr, nc)
   # intersect with existing window
   W$m <- W$m & mm
@@ -105,7 +106,8 @@ pixellate.psp <- function(x, W=NULL, ..., weights=NULL,
                     pixheight=as.double(Z$ystep),
                     nx=as.integer(nc),
                     ny=as.integer(nr),
-                    out=as.double(numeric(nr * nc)))
+                    out=as.double(numeric(nr * nc)),
+                    PACKAGE = "spatstat")
          },
          number = {
            zz <- .C("seg2pixN",
@@ -117,7 +119,8 @@ pixellate.psp <- function(x, W=NULL, ..., weights=NULL,
                     w=as.double(weights),
                     nx=as.integer(nc),
                     ny=as.integer(nr),
-                    out=as.double(numeric(nr * nc)))
+                    out=as.double(numeric(nr * nc)),
+                    PACKAGE = "spatstat")
          })
   mm <- matrix(zz$out, nr, nc)
   mm[is.na(Z$v)] <- NA

--- a/R/pspcross.R
+++ b/R/pspcross.R
@@ -50,7 +50,8 @@ crossing.psp <- function(A,B,fatal=TRUE,details=FALSE) {
               yy=as.double(numeric(na * nb)),
               ta=as.double(numeric(na * nb)),
               tb=as.double(numeric(na * nb)),
-              ok=as.integer(integer(na * nb)))
+              ok=as.integer(integer(na * nb)),
+              PACKAGE = "spatstat")
     
     ok <- (matrix(out$ok, na, nb) != 0)
     xx <- matrix(out$xx, na, nb)
@@ -128,7 +129,8 @@ test.crossing.psp <- function(A,B) {
             dxb=as.double(dxb),
             dyb=as.double(dyb), 
             eps=as.double(eps),
-            ok=as.integer(integer(na * nb)))
+            ok=as.integer(integer(na * nb)),
+            PACKAGE = "spatstat")
 
   hit <- (matrix(out$ok, na, nb) != 0)
   return(hit)
@@ -167,7 +169,8 @@ anycrossing.psp <- function(A,B) {
             dxb=as.double(dxb),
             dyb=as.double(dyb), 
             eps=as.double(eps),
-            ok=as.integer(integer(1L)))
+            ok=as.integer(integer(1L)),
+            PACKAGE = "spatstat")
   hit <- (out$ok != 0)
   return(hit)
 }
@@ -197,7 +200,8 @@ selfcrossing.psp <- function(A) {
               yy=as.double(numeric(n^2)),
               ti=as.double(numeric(n^2)),
               tj=as.double(numeric(n^2)),
-              ok=as.integer(integer(n^2)))
+              ok=as.integer(integer(n^2)),
+              PACKAGE = "spatstat")
 
     ok <- (matrix(out$ok, n, n) != 0)
     xx <- matrix(out$xx, n, n)
@@ -242,7 +246,8 @@ test.selfcrossing.psp <- function(A) {
             dx=as.double(dx),
             dy=as.double(dy), 
             eps=as.double(eps),
-            ok=as.integer(integer(n*n)))
+            ok=as.integer(integer(n*n)),
+            PACKAGE = "spatstat")
   hit <- (matrix(out$ok, n, n) != 0)
   return(hit)
 }

--- a/R/pspcross.R
+++ b/R/pspcross.R
@@ -80,8 +80,8 @@ crossing.psp <- function(A,B,fatal=TRUE,details=FALSE) {
                  y0b, 
                  dxb, 
                  dyb, 
-    	         eps)
-#                 PACKAGE="spatstat")
+    	           eps,
+                 PACKAGE="spatstat")
     xx <- out[[5]]
     yy <- out[[6]]
     if(details) {
@@ -218,8 +218,8 @@ selfcrossing.psp <- function(A) {
                  y0, 
                  dx, 
                  dy, 
-    	         eps)
-#                 PACKAGE="spatstat")
+    	           eps,
+                 PACKAGE="spatstat")
     xx <- out[[5L]]
     yy <- out[[6L]]
   }
@@ -276,7 +276,8 @@ selfcut.psp <- function(A, ..., eps) {
               y0, 
               dx, 
               dy, 
-              eps)
+              eps,
+              PACKAGE = "spatstat")
   if(length(zz[[1]]) == 0)
     return(A)
   ##

--- a/R/quasirandom.R
+++ b/R/quasirandom.R
@@ -11,7 +11,8 @@ vdCorput <- function(n, base) {
   z <- .C("Corput",
           base=as.integer(base),
           n=as.integer(n),
-          result=as.double(numeric(n)))
+          result=as.double(numeric(n)),
+          PACKAGE = "spatstat")
   return(z$result)
 }
 

--- a/R/rPerfect.R
+++ b/R/rPerfect.R
@@ -46,7 +46,8 @@ rStrauss <- function(beta, gamma=1, R=0, W=owin(), expand=TRUE,
                gamma,
                R,
                xrange,
-               yrange)
+               yrange,
+               PACKAGE = "spatstat")
 
     X <- z[[1]]
     Y <- z[[2]]
@@ -102,7 +103,8 @@ rHardcore <- function(beta, R=0, W=owin(), expand=TRUE, nsim=1, drop=TRUE) {
                beta,
                R,
                xrange,
-               yrange)
+               yrange,
+               PACKAGE = "spatstat")
 
     X <- z[[1]]
     Y <- z[[2]]
@@ -171,7 +173,8 @@ rStraussHard <- function(beta, gamma=1, R=0, H=0, W=owin(),
                R,
                H,
                xrange,
-               yrange)
+               yrange,
+               PACKAGE = "spatstat")
 
     X <- z[[1]]
     Y <- z[[2]]
@@ -237,7 +240,8 @@ rDiggleGratton <- function(beta, delta, rho, kappa=1, W=owin(),
                rho,
                kappa,
                xrange,
-               yrange)
+               yrange,
+               PACKAGE = "spatstat")
 
     X <- z[[1]]
     Y <- z[[2]]
@@ -294,7 +298,8 @@ rDGS <- function(beta, rho, W=owin(), expand=TRUE, nsim=1, drop=TRUE) {
                beta,
                rho,
                xrange,
-               yrange)
+               yrange,
+               PACKAGE = "spatstat")
 
     X <- z[[1]]
     Y <- z[[2]]
@@ -356,7 +361,8 @@ rPenttinen <- function(beta, gamma=1, R, W=owin(),
                gamma,
                R,
                xrange,
-               yrange)
+               yrange,
+               PACKAGE = "spatstat")
 
     X <- z[[1]]
     Y <- z[[2]]

--- a/R/random.R
+++ b/R/random.R
@@ -921,7 +921,8 @@ thinjump <- function(n, p) {
   if(p > 0.5) return(-thinjump(n, 1-p))
   guessmaxlength <- ceiling(n * p + 2 * sqrt(n * p * (1-p)))
   i <- .Call("thinjumpequal",
-             n, p, guessmaxlength)
+             n, p, guessmaxlength,
+             PACKAGE = "spatstat")
   return(i)
 }
   

--- a/R/rmh.default.R
+++ b/R/rmh.default.R
@@ -869,8 +869,8 @@ rmhEngine <- function(InfoList, ...,
                  thin,
                  snoopenv,
                  temper,
-                 invertemp)
-#                 PACKAGE="spatstat")
+                 invertemp,
+                 PACKAGE="spatstat")
   
     # Extract the point pattern returned from C
     X <- ppp(x=out[[1L]], y=out[[2L]], window=w.state, check=FALSE)
@@ -984,7 +984,8 @@ rmhEngine <- function(InfoList, ...,
                    thin,
                    snoopenv,
                    temper,
-                   invertemp)
+                   invertemp,
+                   PACKAGE = "spatstat")
       # Extract the point pattern returned from C
       X <- ppp(x=out[[1L]], y=out[[2L]], window=w.state, check=FALSE)
       if(mtype) {

--- a/R/rmhmodel.R
+++ b/R/rmhmodel.R
@@ -200,7 +200,8 @@ rmhmodel.default <- local({
     if(!is.na(C.id)) {
       z <- .C("knownCif",
               cifname=as.character(C.id),
-              answer=as.integer(0))
+              answer=as.integer(0),
+              PACKAGE = "spatstat")
       ok <- as.logical(z$answer)
       if(!ok)
         stop(paste("Internal error: the cif", sQuote(C.id),

--- a/R/scanstat.R
+++ b/R/scanstat.R
@@ -43,7 +43,8 @@ scanmeasure.ppp <- function(X, r, ..., method=c("counts", "fft")) {
                     nr=as.integer(nr),
                     nc=as.integer(nc),
                     R=as.double(r),
-                    counts=as.integer(numeric(prod(dimyx))))
+                    counts=as.integer(numeric(prod(dimyx))),
+                    PACKAGE = "spatstat")
            zzz <- matrix(zz$counts, nrow=dimyx[1], ncol=dimyx[2], byrow=TRUE)
            Z <- im(zzz, xrange=xr, yrange=yr, unitname=unitname(X))
          },

--- a/R/smooth.ppp.R
+++ b/R/smooth.ppp.R
@@ -340,7 +340,8 @@ smoothpointsEngine <- function(x, values, sigma, ...,
                v       = as.double(vv),
                self    = as.integer(!leaveoneout),
                rmaxi   = as.double(cutoff),
-               result  = as.double(double(npts)))
+               result  = as.double(double(npts)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[oo] <- zz$result
     } else {
       wtsort <- weights[oo]
@@ -352,7 +353,8 @@ smoothpointsEngine <- function(x, values, sigma, ...,
                self    = as.integer(!leaveoneout),
                rmaxi   = as.double(cutoff),
                weight  = as.double(wtsort),
-               result  = as.double(double(npts)))
+               result  = as.double(double(npts)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[oo] <- zz$result
     }
     if(any(nbg <- (is.infinite(result) | is.nan(result)))) {
@@ -388,7 +390,8 @@ smoothpointsEngine <- function(x, values, sigma, ...,
                  self    = as.integer(!leaveoneout),
                  rmaxi   = as.double(cutoff),
                  sig     = as.double(sd),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result
       } else {
         wtsort <- weights[oo]
@@ -401,7 +404,8 @@ smoothpointsEngine <- function(x, values, sigma, ...,
                  rmaxi   = as.double(cutoff),
                  sig     = as.double(sd),
                  weight  = as.double(wtsort),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result
       }
     } else {
@@ -417,7 +421,8 @@ smoothpointsEngine <- function(x, values, sigma, ...,
                  self    = as.integer(!leaveoneout),
                  rmaxi   = as.double(cutoff),
                  sinv    = as.double(flatSinv),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result
       } else {
         wtsort <- weights[oo]
@@ -430,7 +435,8 @@ smoothpointsEngine <- function(x, values, sigma, ...,
                  rmaxi   = as.double(cutoff),
                  sinv    = as.double(flatSinv),
                  weight  = as.double(wtsort),
-                 result  = as.double(double(npts)))
+                 result  = as.double(double(npts)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[oo] <- zz$result
       }
     }
@@ -682,7 +688,8 @@ smoothcrossEngine <- function(Xdata, Xquery, values, sigma, ...,
                vd      = as.double(vd),
                rmaxi   = as.double(cutoff),
                sig     = as.double(sd),
-               result  = as.double(double(nquery)))
+               result  = as.double(double(nquery)),
+               PACKAGE = "spatstat")
       if(sorted) result <- zz$result else result[ooq] <- zz$result
     } else {
       wtsort <- weights[ood]
@@ -697,7 +704,8 @@ smoothcrossEngine <- function(Xdata, Xquery, values, sigma, ...,
                wd      = as.double(wtsort),
                rmaxi   = as.double(cutoff),
                sig     = as.double(sd),
-               result  = as.double(double(nquery)))
+               result  = as.double(double(nquery)),
+               PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[ooq] <- zz$result
       }
     } else {
@@ -715,7 +723,8 @@ smoothcrossEngine <- function(Xdata, Xquery, values, sigma, ...,
                  vd      = as.double(vd),
                  rmaxi   = as.double(cutoff),
                  sinv    = as.double(flatSinv),
-                 result  = as.double(double(nquery)))
+                 result  = as.double(double(nquery)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[ooq] <- zz$result
       } else {
         wtsort <- weights[ood]
@@ -730,7 +739,8 @@ smoothcrossEngine <- function(Xdata, Xquery, values, sigma, ...,
                  wd      = as.double(wtsort),
                  rmaxi   = as.double(cutoff),
                  sinv    = as.double(flatSinv),
-                 result  = as.double(double(nquery)))
+                 result  = as.double(double(nquery)),
+                 PACKAGE = "spatstat")
         if(sorted) result <- zz$result else result[ooq] <- zz$result
       }
     }

--- a/R/sparselinalg.R
+++ b/R/sparselinalg.R
@@ -171,7 +171,8 @@ sumsymouterSparse <- function(x, w=NULL, dbg=FALSE) {
             kx = as.integer(df$k),
             x  = as.double(df$value),
             flip = as.integer(ff - 1L), # convert 1-based to 0-based
-            y  = as.double(numeric(m * m)))
+            y  = as.double(numeric(m * m)),
+            PACKAGE = "spatstat")
   } else {
     # extract triplet representation of w
     w <- as(w, Class="TsparseMatrix")
@@ -191,7 +192,8 @@ sumsymouterSparse <- function(x, w=NULL, dbg=FALSE) {
             jw = as.integer(dfw$j),
             kw = as.integer(dfw$k),
             w = as.double(dfw$w),
-            y  = as.double(numeric(m * m)))
+            y  = as.double(numeric(m * m)),
+            PACKAGE = "spatstat")
   }
   y <- matrix(z$y, m, m)
   dimnames(y) <- rep(dimnames(x)[1], 2)

--- a/R/strauss.R
+++ b/R/strauss.R
@@ -151,7 +151,8 @@ crosspaircounts <- function(X, Y, r) {
             xtarget  = as.double(Ysort$x),
             ytarget  = as.double(Ysort$y),
             rrmax    = as.double(r),
-            counts   = as.integer(integer(nX)))
+            counts   = as.integer(integer(nX)),
+            PACKAGE = "spatstat")
   answer <- integer(nX)
   answer[oX] <- out$counts
   return(answer)
@@ -172,7 +173,8 @@ closepaircounts <- function(X, r) {
             x      = as.double(Xsort$x),
             y      = as.double(Xsort$y),
             rmaxi  = as.double(r),
-            counts = as.integer(integer(nX)))
+            counts = as.integer(integer(nX)),
+            PACKAGE = "spatstat")
   answer <- integer(nX)
   answer[oX] <- out$counts
   return(answer)

--- a/R/weightedStats.R
+++ b/R/weightedStats.R
@@ -30,7 +30,8 @@ whist <- function(x, breaks, weights=NULL) {
           h <- unlist(lapply(split(weights, cell), sum, na.rm=TRUE))
         } else {
           h <- .Call("Cwhist",
-                     as.integer(cell), as.double(weights), as.integer(nb))
+                     as.integer(cell), as.double(weights), as.integer(nb),
+                     PACKAGE = "spatstat")
         }
       }
     }

--- a/R/wingeom.R
+++ b/R/wingeom.R
@@ -168,8 +168,8 @@ owinpoly2mask <- function(w, rasta, check=TRUE) {
             np=as.integer(np),
             nx=as.integer(nx),
             ny=as.integer(ny),
-            out=as.integer(integer(nx * ny)))
-#            PACKAGE="spatstat")
+            out=as.integer(integer(nx * ny)),
+            PACKAGE="spatstat")
     if(i == 1)
       score <- z$out
     else 
@@ -812,7 +812,8 @@ bdry.mask <- function(W) {
             nx = as.integer(nc),
             ny = as.integer(nr),
             m = as.integer(m),
-            b = as.integer(b))
+            b = as.integer(b),
+            PACKAGE = "spatstat")
     b <- matrix(as.logical(z$b), nr, nc)
   }
   W$m <- b
@@ -1053,7 +1054,8 @@ discs <- function(centres, radii=marks(centres)/2, ...,
             xd    = as.double(centres$x),
             yd    = as.double(centres$y),
             rd    = as.double(radii), 
-            out   = as.integer(integer(prod(M$dim))))
+            out   = as.integer(integer(prod(M$dim))),
+            PACKAGE = "spatstat")
     M$m[] <- as.logical(z$out)
     return(M)
   }


### PR DESCRIPTION
The `spatstat` package is going to feature prominently in an upcoming DataCamp course. Unfortunately, neither the version on CRAN, nor the development version work correctly on the DataCamp platform.  The problem is that when C code is called, sometimes an error occurs regarding locating the call.

```r
ppp(x=runif(10), y=runif(10), window=disc(radius=10))
## Error: "Cmatchxy" not resolved from current namespace (spatstat)
```

The fix is to include a `PACKAGE` argument to calls to `.C()` and `.Call()`. This fix should be applicable to other platforms too, making `spatstat` more widely available.

I've also made this change to the dependencies `spatstat.utils` and `polyclip`.