### PR TITLE
edited convolve.im to preserve unitname from input

### DIFF
--- a/R/setcov.R
+++ b/R/setcov.R
@@ -102,6 +102,7 @@ convolve.im <- function(X, Y=X, ..., reflectX=FALSE, reflectY=FALSE) {
   yran <- XB$yrange + YB$yrange
   # Declare spatial domain
   out <- im(G, xrange = xran, yrange=yran)
+  unitname(out) <- unitname(X)
   if(crosscov) {
     # restrict to actual spatial domain of function
     if(reflectX) Xbox <- reflect(Xbox)


### PR DESCRIPTION
convolve.im, setcov, imcov now return im objects with the unitname of the input X image.

eg. convolve.im(as.im(heather$coarse, na.replace = 0)) now returns an object with unitname of "metre / metres", which is equal to unitname(heather$coarse).

Previously convolve.im() would return an im object with unitname of "unit / units"