### PR TITLE
Detect minimum contrast parameters in optional argument ctrl of dppm.

### DIFF
--- a/R/dppm.R
+++ b/R/dppm.R
@@ -81,7 +81,9 @@ spatstatDPPModelInfo <- function(model){
     resolvedots = function(...){
       ## returning the input arguments p, q, rmin, rmax in list with one element 'ctrl'
       dots <- list(...)
-      return(list(ctrl = dots[c("p", "q", "rmin", "rmax")]))
+      ctrl <- resolve.defaults(dots$ctrl, dots[c("p", "q", "rmin", "rmax")],
+                               .StripNull = TRUE)
+      return(list(ctrl = ctrl))
     },
     ## K-function
     K = function(par, rvals, ...){


### PR DESCRIPTION
If `ctrl` was passed in the dots of `dppm()` it wasn't detected. With this patch it should now be possible to set parameters this way:

```
library(spatstat)
fit <- dppm(swedishpines~1, dppGauss(), ctrl=list(rmin=1,q=1))
fit$Fit$mcfit$ctrl # The guts now contain the specified values
```