### PR TITLE
Add group option to rlabel()

### DIFF
--- a/R/rlabel.R
+++ b/R/rlabel.R
@@ -28,6 +28,8 @@ rlabel <- function(X, labels=marks(X), group=NULL, permute=TRUE, nsim=1, drop=TR
                    X %mark% labels[sample(1:nlabels, nthings, replace=!permute), ,drop=FALSE],
                    simplify=FALSE)
     if ( !is.null(group) ) {
+      if ( ! group %in% names(labels) )
+        stop(paste(group, "should be in names of marks"))
       olabels <- order(labels[,group])
       Z <- lapply(Y, FUN= function(x) { 
         ox <- order( marks(x)[,group] )

--- a/R/rlabel.R
+++ b/R/rlabel.R
@@ -6,7 +6,7 @@
 #   $Revision: 1.12 $   $Date: 2019/04/25 02:59:12 $
 #
 #
-rlabel <- function(X, labels=marks(X), permute=TRUE, nsim=1, drop=TRUE) {
+rlabel <- function(X, labels=marks(X), group=NULL, permute=TRUE, nsim=1, drop=TRUE) {
   stopifnot(is.ppp(X) || is.lpp(X) || is.pp3(X) || is.ppx(X) || is.psp(X))
   if(is.null(labels))
     stop("labels not given and marks not present")
@@ -27,6 +27,16 @@ rlabel <- function(X, labels=marks(X), permute=TRUE, nsim=1, drop=TRUE) {
     Y <- replicate(nsim,
                    X %mark% labels[sample(1:nlabels, nthings, replace=!permute), ,drop=FALSE],
                    simplify=FALSE)
+    if ( !is.null(group) ) {
+      olabels <- order(labels[,group])
+      Z <- lapply(Y, FUN= function(x) { 
+        ox <- order( marks(x)[,group] )
+        sx <- marks(x)[ox,]
+        marks(x) <-sx[order(olabels),]
+        x
+      } )
+      Y <- Z
+    }
   } else stop("Format of labels argument is not understood")
   return(simulationresult(Y, nsim, drop))
 }


### PR DESCRIPTION
Dear spatstat developers,

I am suggesting to add group option in rlabel(), to enable random labeling with groups (eg. relabel DBH within species).

_Motivation:_ image you have trees over the plot, marks are species identity and DBH. I would like to do random labeling that will leave species on the original/observed positions, but relabel only DBH marks within species. So I would like to have something like: rlabel(x, group="species"), where x is ppp with two marks, DBH and species. Actualy, rlabel() for data.frame marks changes positions of marks (it sample()s rows, so eg. for DBH and species marks does not break distributions of DBH over species, but it changes their positions ).

_Coding:_ I just add (after you calling replicate) check for group option (group will be the name of the column in data.frame, eg. "species"), if group is not specified nothing changes. Then I get order of original/observed group marks and on each of random/null community in Y, I changed order according group to be the same in the observed pattern. Your original replicate relabel individuals over the plot, my sorting just move species on the original positions, but now they can have different DBH marks, but species are on the original/observed positions. I made several tests and checks.

What do you thing?

Best regards and thank you for your great work, Pavel