### PR TITLE
check cran version before warning about outdated local version

### DIFF
--- a/R/versions.R
+++ b/R/versions.R
@@ -63,8 +63,15 @@ versioncurrency.spatstat <- function(today=Sys.Date(), checkR=TRUE) {
   if(is.null(msg)) {
     ## check version of spatstat
     descfile <- system.file("DESCRIPTION", package="spatstat")
-    packdate <- as.Date(read.dcf(file=descfile, fields="Date"))
-    elapsed <- today - packdate
+    ap <- available.packages()
+    cran_version <- ap[ap[, 1] == "spatstat", 2]
+    local_version <- as.character(read.dcf(file=descfile, fields="Version"))
+    if (identical(cran_version, local_version)) {
+        elapsed <- 0
+    } else {
+        packdate <- as.Date(read.dcf(file=descfile, fields="Date"))
+        elapsed <- today - packdate
+    }
     if(elapsed > 75) {
       if(elapsed > 365) {
         n <- floor(elapsed/365)


### PR DESCRIPTION
Just a suggestion, and you may prefer other approaches, but this at least suppresses the startup message proclaiming that the latest CRAN version is "out of date by more than 6 months". `available.packages()` does of course require an internet connection, and performs a `GET` request, so i'll understand if you'd prefer not to have that in a package that otherwise functions perfectly offline.